### PR TITLE
feat(web): rebrand consumer-facing name to "Current"

### DIFF
--- a/web/branding/app.json
+++ b/web/branding/app.json
@@ -1,0 +1,3 @@
+{
+  "name": "Current"
+}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -3,8 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Freenet Microblogging</title>
-    <script type="module" crossorigin src="./assets/index-Bb3-XcUe.js"></script>
+    <!-- <title> is set at runtime in src/index.ts using APP_NAME
+         from src/branding.ts (sourced from branding/app.json). -->
+    <title></title>
+    <script type="module" crossorigin src="./assets/index-BFyo3hJO.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-BLg2lTmG.css">
   </head>
   <body>

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Freenet Microblogging</title>
+    <!-- <title> is set at runtime in src/index.ts using APP_NAME
+         from src/branding.ts (sourced from branding/app.json). -->
+    <title></title>
   </head>
   <body>
     <div id="app"></div>

--- a/web/src/branding.ts
+++ b/web/src/branding.ts
@@ -1,0 +1,6 @@
+// Consumer-facing branding loaded once from `web/branding/app.json`.
+// Single source of truth for the product name, shared with any future
+// test suites that read the same file.
+import branding from "../branding/app.json";
+
+export const APP_NAME: string = branding.name;

--- a/web/src/components/onboarding.ts
+++ b/web/src/components/onboarding.ts
@@ -5,6 +5,8 @@
  * with inline styles so no SCSS changes are needed.
  */
 
+import { APP_NAME } from "../branding";
+
 export function createOnboarding(
   onComplete: (displayName: string, secretKey?: string) => void
 ): HTMLElement {
@@ -19,15 +21,15 @@ export function createOnboarding(
   const card = document.createElement("div");
   card.className = "onboarding-card";
 
-  // Freenet logo mark
+  // App logo mark — first character of the app name
   const logo = document.createElement("div");
   logo.className = "onboarding-logo";
-  logo.textContent = "F";
+  logo.textContent = APP_NAME.charAt(0).toUpperCase();
 
   // Title
   const title = document.createElement("h1");
   title.className = "onboarding-title";
-  title.textContent = "Welcome to Freenet";
+  title.textContent = `Welcome to ${APP_NAME}`;
 
   // Subtitle
   const subtitle = document.createElement("p");

--- a/web/src/components/sidebar.ts
+++ b/web/src/components/sidebar.ts
@@ -1,3 +1,4 @@
+import { APP_NAME } from "../branding";
 import { toggleTheme } from "../theme";
 import { getIdentity } from "../identity";
 
@@ -55,7 +56,7 @@ export function createSidebar(callbacks?: SidebarCallbacks): HTMLElement {
 
   const logoText = document.createElement("span");
   logoText.className = "sidebar-logo__text";
-  logoText.textContent = "freenet";
+  logoText.textContent = APP_NAME.toLowerCase();
 
   logo.appendChild(logoCircle);
   logo.appendChild(logoText);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,4 +1,5 @@
 import "./scss/styles.scss";
+import { APP_NAME } from "./branding";
 import { createApp } from "./app";
 import { FreenetConnection } from "./freenet-api";
 import { Post } from "./types";
@@ -13,6 +14,8 @@ import {
 } from "./identity";
 import { parseDelegateResponse } from "./delegate-api";
 import { DelegateResponse } from "@freenetorg/freenet-stdlib";
+
+document.title = APP_NAME;
 
 const appRoot = document.getElementById("app")!;
 

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "noImplicitAny": true,
+    "resolveJsonModule": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
@@ -15,5 +16,5 @@
     "outDir": "./dist",
     "types": ["vite/client"]
   },
-  "include": ["src"]
+  "include": ["src", "branding/app.json"]
 }


### PR DESCRIPTION
## Summary
- Rename user-visible app name from "Freenet Microblogging" to **Current** in the browser title, sidebar logo, and onboarding welcome screen.
- Branding lives in `web/branding/app.json` as a single source of truth, loaded via `web/src/branding.ts` so any future Playwright/Vitest suite can read the same file.
- Mirrors the pattern from freenet/mail#24 (which rebranded "Freenet Email" → "Mail").

Unchanged:
- Crate/package names, contract identifiers, repo docs.
- Network-level references (About Freenet card, freenet.org link, splash "Connecting to Freenet…", compose placeholder "What's happening on Freenet?") — these describe the underlying network, not the app product.

## Test plan
- [x] `npm run build` succeeds (tsc + vite)
- [x] Bundle contains `Current` and no stale `Freenet Microblogging` string
- [ ] Manual: visit onboarding, confirm heading reads "Welcome to Current" and logo mark is "C"
- [ ] Manual: confirm browser tab title is "Current"
- [ ] Manual: confirm sidebar logo reads "current"