### PR TITLE
feat: contract migration system foundation (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ node_modules/
 /target/webapp/
 web/dist/
 web/model_code_hash.txt
+web/follows_contract_id.txt
+web/likes_contract_id.txt
 web/delegate_key.txt
 web/delegate_key_bytes.json
 web/delegate_code_hash_bytes.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,75 @@ cd web && npm test                              # Web app (Vitest)
 - Rust toolchain with `wasm32-unknown-unknown` target
 - `freenet` and `fdev` CLI tools (`cargo install freenet fdev`)
 
+## Contract migration
+
+A contract's WASM hash changes whenever its source or any WASM-affecting
+dependency changes, and the contract key is derived from that hash. So a bump
+moves every user's state to a new key — stranding the old state unless we
+migrate it. The migration system (issue #20) detects a bump on startup and
+pulls stranded state into the new key. It runs in `FreenetConnection.connect`
+(`web/src/freenet-api.ts`) before subscribing.
+
+### Schema-tolerance policy (MANDATORY)
+
+Every additive field on a contract state struct MUST carry
+`#[serde(default, skip_serializing_if = …)]` (or at least `#[serde(default)]`
+for non-`Option` fields) so older wire shapes still decode under newer code.
+Never put `#[serde(deny_unknown_fields)]` on contract state — unknown
+forward-compat fields must be ignored, not rejected.
+
+- Audited structs: `PostsFeed` / `Post` (`contracts/posts/src/lib.rs`),
+  `FollowGraph` (`contracts/follows/src/lib.rs`), `LikeGraph`
+  (`contracts/likes/src/lib.rs`). Each has a `decodes_old_shape_state` test.
+- A schema change that CANNOT be expressed as an additive serde-default field
+  (renames, type changes, restructures) is **not** byte-compatible: it needs a
+  dedicated re-shape pass in the migration writer and cannot ride a plain hash
+  bump.
+
+### Build isolation
+
+Every dependency that influences WASM output is pinned to an exact version
+(`=x.y.z`) in each contract/delegate `Cargo.toml` and in the workspace
+`freenet-stdlib` entry. The committed workspace `Cargo.lock` pins transitive
+deps, and the Rust toolchain is fixed via `rust-toolchain.toml`. Together these
+guarantee a routine dependency bump cannot silently rotate a contract's WASM
+hash — a rotation is always a deliberate edit.
+
+### Bump recipe (rotating a contract deliberately)
+
+1. Make the change (edit contract source, or bump a `=x.y.z` pin in its
+   `Cargo.toml`).
+2. Keep the schema byte-compatible — additive serde-default fields only. A
+   JSON-schema change in the same release would fail `validate_state` per user;
+   split it out with a dedicated re-shape pass.
+3. `cargo make build-contracts` to regenerate the WASM + hashes.
+4. Append the **prior** hash (the previous current-hash value) to that
+   contract's legacy list in `web/src/migrations/legacy-hashes.ts`
+   (`LEGACY_POSTS_CODE_HASHES` / `LEGACY_FOLLOWS_CODE_HASHES` /
+   `LEGACY_LIKES_CODE_HASHES`). Append-only, oldest → newest — never reorder or
+   delete. The new current hash MUST NOT appear in the legacy list (enforced by
+   `legacy-hashes.test.ts`).
+5. Ship. On next load the migration loop GETs the old key, decodes its state,
+   and re-injects it under the new key.
+
+### Helpers
+
+- `web/src/migrations/legacy-hashes.ts` — per-contract legacy lists + current
+  hashes (wired from `web/vite.config.ts`) + the `MIGRATABLE_CONTRACTS` registry.
+- `web/src/migrations/candidates.ts` — pure `buildMigrationCandidates` /
+  `selectMigrateFrom` (ported from mail `ui/src/inbox.rs`).
+- `web/src/migrations/state-store.ts` — `MigrationStateStore` (localStorage-
+  backed today; a delegate-backed store swaps in for the per-identity era).
+- `web/src/migrations/run.ts` — `runMigrations`, the startup loop.
+
+### Deferred (per-identity — lands with #11/#13)
+
+Once profile/posts contracts become per-identity, extend the identity delegate's
+secret storage with a `{ contract_type → recorded_hash }` map (mirroring mail's
+`AliasInfo`) and run the same `selectMigrateFrom` / candidate-chain / re-inject
+flow against each identity's derived key. Cross-version contact interop follows
+then.
+
 ## Conventions
 
 - All Freenet protocol messages use FlatBuffers types from the stdlib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ codegen-units = 1
 panic = 'abort'
 
 [workspace.dependencies]
-freenet-stdlib = { version = "0.6.1", default-features = false, features = ["contract"] }
+# Pinned exact (=x.y.z) for contract build isolation: a freenet-stdlib bump
+# rotates contract WASM hashes, so it must be deliberate and paired with the
+# migration story. See AGENTS.md → "Contract migration".
+freenet-stdlib = { version = "=0.6.1", default-features = false, features = ["contract"] }
 freenet-microblogging-common = { path = "common" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,7 +14,8 @@ set -euo pipefail
 ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
 cargo clean
 rm -rf "$ROOT/web/dist" "$ROOT/web/build" "$ROOT/build" "$ROOT/target/webapp"
-rm -f "$ROOT/web/model_code_hash.txt" "$ROOT/web/delegate_key.txt" \
+rm -f "$ROOT/web/model_code_hash.txt" "$ROOT/web/follows_contract_id.txt" \
+      "$ROOT/web/likes_contract_id.txt" "$ROOT/web/delegate_key.txt" \
       "$ROOT/web/delegate_key_bytes.json" "$ROOT/web/delegate_code_hash_bytes.json"
 '''
 
@@ -54,12 +55,18 @@ set -euo pipefail
 ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
 cd "$ROOT/contracts/follows"
 CARGO_TARGET_DIR="$ROOT/target" fdev build
+WASM="$ROOT/target/wasm32-unknown-unknown/release/freenet_microblogging_follows.wasm"
 hash=$(CARGO_TARGET_DIR="$ROOT/target" fdev inspect \
     "$ROOT/contracts/follows/build/freenet/freenet_microblogging_follows" code | \
     grep 'code hash:' | cut -d' ' -f3)
+# Contract instance id (empty parameters) — the migration system records this
+# as CURRENT_FOLLOWS_CODE_HASH via web/vite.config.ts.
+instance_id=$(CARGO_TARGET_DIR="$ROOT/target" fdev get-contract-id --code "$WASM")
 mkdir -p "$ROOT/build"
 printf '%s' "$hash" > "$ROOT/build/follows_code_hash"
+printf '%s' "$instance_id" > "$ROOT/web/follows_contract_id.txt"
 echo "wrote build/follows_code_hash: $hash"
+echo "wrote web/follows_contract_id.txt: $instance_id"
 '''
 
 [tasks.build-likes]
@@ -70,12 +77,18 @@ set -euo pipefail
 ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
 cd "$ROOT/contracts/likes"
 CARGO_TARGET_DIR="$ROOT/target" fdev build
+WASM="$ROOT/target/wasm32-unknown-unknown/release/freenet_microblogging_likes.wasm"
 hash=$(CARGO_TARGET_DIR="$ROOT/target" fdev inspect \
     "$ROOT/contracts/likes/build/freenet/freenet_microblogging_likes" code | \
     grep 'code hash:' | cut -d' ' -f3)
+# Contract instance id (empty parameters) — the migration system records this
+# as CURRENT_LIKES_CODE_HASH via web/vite.config.ts.
+instance_id=$(CARGO_TARGET_DIR="$ROOT/target" fdev get-contract-id --code "$WASM")
 mkdir -p "$ROOT/build"
 printf '%s' "$hash" > "$ROOT/build/likes_code_hash"
+printf '%s' "$instance_id" > "$ROOT/web/likes_contract_id.txt"
 echo "wrote build/likes_code_hash: $hash"
+echo "wrote web/likes_contract_id.txt: $instance_id"
 '''
 
 [tasks.build-identity]

--- a/contracts/follows/Cargo.toml
+++ b/contracts/follows/Cargo.toml
@@ -6,10 +6,12 @@ rust-version = "1.85"
 resolver = "2"
 publish = false
 
+# Build isolation: WASM-affecting deps pinned to exact versions (=x.y.z).
+# See AGENTS.md → "Contract migration".
 [dependencies]
 freenet-stdlib = { workspace = true, features = ["contract"] }
-serde = "1"
-serde_json = "1"
+serde = "=1.0.228"
+serde_json = "=1.0.149"
 
 [lib]
 crate-type = ["cdylib"]

--- a/contracts/follows/src/lib.rs
+++ b/contracts/follows/src/lib.rs
@@ -5,6 +5,9 @@ use std::collections::{HashMap, HashSet};
 /// State: maps user public keys to their set of followed public keys
 #[derive(Serialize, Deserialize)]
 struct FollowGraph {
+    // Schema-tolerance: defaults so older/newer wire shapes still decode.
+    // See AGENTS.md → "Contract migration".
+    #[serde(default)]
     follows: HashMap<String, HashSet<String>>,
 }
 
@@ -129,6 +132,18 @@ mod test {
         )
         .unwrap();
         assert!(matches!(result, ValidateResult::Valid));
+    }
+
+    #[test]
+    fn decodes_old_shape_state() {
+        // Schema-tolerance guard: an empty object decodes to an empty graph
+        // (follows defaults), and an unknown forward-compat field is ignored.
+        let empty: FollowGraph = serde_json::from_slice(b"{}").unwrap();
+        assert!(empty.follows.is_empty());
+
+        let forward = r#"{"follows":{"alice":["bob"]},"version":2}"#;
+        let graph: FollowGraph = serde_json::from_slice(forward.as_bytes()).unwrap();
+        assert!(graph.follows["alice"].contains("bob"));
     }
 
     #[test]

--- a/contracts/likes/Cargo.toml
+++ b/contracts/likes/Cargo.toml
@@ -6,10 +6,12 @@ rust-version = "1.85"
 resolver = "2"
 publish = false
 
+# Build isolation: WASM-affecting deps pinned to exact versions (=x.y.z).
+# See AGENTS.md → "Contract migration".
 [dependencies]
 freenet-stdlib = { workspace = true, features = ["contract"] }
-serde = "1"
-serde_json = "1"
+serde = "=1.0.228"
+serde_json = "=1.0.149"
 
 [lib]
 crate-type = ["cdylib"]

--- a/contracts/likes/src/lib.rs
+++ b/contracts/likes/src/lib.rs
@@ -5,6 +5,9 @@ use std::collections::{HashMap, HashSet};
 /// State: maps post_id to the set of public keys that liked that post
 #[derive(Serialize, Deserialize)]
 struct LikeGraph {
+    // Schema-tolerance: defaults so older/newer wire shapes still decode.
+    // See AGENTS.md → "Contract migration".
+    #[serde(default)]
     likes: HashMap<String, HashSet<String>>,
 }
 
@@ -129,6 +132,18 @@ mod test {
         )
         .unwrap();
         assert!(matches!(result, ValidateResult::Valid));
+    }
+
+    #[test]
+    fn decodes_old_shape_state() {
+        // Schema-tolerance guard: an empty object decodes to an empty graph
+        // (likes defaults), and an unknown forward-compat field is ignored.
+        let empty: LikeGraph = serde_json::from_slice(b"{}").unwrap();
+        assert!(empty.likes.is_empty());
+
+        let forward = r#"{"likes":{"post_1":["alice"]},"version":2}"#;
+        let graph: LikeGraph = serde_json::from_slice(forward.as_bytes()).unwrap();
+        assert!(graph.likes["post_1"].contains("alice"));
     }
 
     #[test]

--- a/contracts/posts/Cargo.toml
+++ b/contracts/posts/Cargo.toml
@@ -6,18 +6,21 @@ rust-version = "1.85"
 resolver = "2"
 publish = false
 
+# Build isolation: every dep that influences WASM output is pinned to an exact
+# version (=x.y.z). A deliberate contract rotation requires editing a pin and
+# pairing it with the migration story. See AGENTS.md → "Contract migration".
 [dependencies]
-byteorder = "1"
+byteorder = "=1.5.0"
 freenet-stdlib = { workspace = true, features = ["contract"] }
-serde = "1"
-serde_json = "1"
+serde = "=1.0.228"
+serde_json = "=1.0.149"
 
 [lib]
 crate-type = ["cdylib"]
 
 [build-dependencies]
-serde = "1"
-serde_json = "1"
+serde = "=1.0.228"
+serde_json = "=1.0.149"
 
 [features]
 default = ["freenet-main-contract"]

--- a/contracts/posts/src/lib.rs
+++ b/contracts/posts/src/lib.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct PostsFeed {
+    // Schema-tolerance: defaults so older/newer wire shapes still decode.
+    // See AGENTS.md → "Contract migration".
+    #[serde(default)]
     posts: Vec<Post>,
 }
 
@@ -19,12 +22,13 @@ impl<'a> TryFrom<State<'a>> for PostsFeed {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Post {
-    pub id: String,                   // unique ID: "{author_pubkey}-{timestamp_ms}"
-    pub author_pubkey: String,        // hex-encoded public key
-    pub author_name: String,          // display name
-    pub author_handle: String,        // @handle
-    pub content: String,              // post text (max 280 chars)
-    pub timestamp: u64,               // unix timestamp milliseconds
+    pub id: String,            // unique ID: "{author_pubkey}-{timestamp_ms}"
+    pub author_pubkey: String, // hex-encoded public key
+    pub author_name: String,   // display name
+    pub author_handle: String, // @handle
+    pub content: String,       // post text (max 280 chars)
+    pub timestamp: u64,        // unix timestamp milliseconds
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signature: Option<Box<[u8]>>, // signature over content bytes
 }
 
@@ -202,6 +206,34 @@ mod test {
             ]
         }"#;
         let _feed = PostsFeed::try_from(State::from(json.as_bytes()))?;
+        Ok(())
+    }
+
+    #[test]
+    fn decodes_old_shape_state() -> Result<(), Box<dyn std::error::Error>> {
+        // Schema-tolerance guard: a post missing `signature` (older wire shape)
+        // and a feed carrying an unknown forward-compat field must both decode.
+        let json = r#"{
+            "version": 2,
+            "posts": [
+                {
+                    "id": "deadbeef-1700000000000",
+                    "author_pubkey": "deadbeef",
+                    "author_name": "Alice",
+                    "author_handle": "@alice",
+                    "content": "Hello world",
+                    "timestamp": 1700000000000,
+                    "reply_to": "future-field"
+                }
+            ]
+        }"#;
+        let feed = PostsFeed::try_from(State::from(json.as_bytes()))?;
+        assert_eq!(feed.posts.len(), 1);
+        assert!(feed.posts[0].signature.is_none());
+
+        // An empty object decodes to an empty feed (posts defaults).
+        let empty = PostsFeed::try_from(State::from(b"{}".as_ref()))?;
+        assert!(empty.posts.is_empty());
         Ok(())
     }
 

--- a/delegates/identity/Cargo.toml
+++ b/delegates/identity/Cargo.toml
@@ -6,13 +6,15 @@ rust-version = "1.85"
 resolver = "2"
 publish = false
 
+# Build isolation: WASM-affecting deps pinned to exact versions (=x.y.z).
+# See AGENTS.md → "Contract migration".
 [dependencies]
 freenet-stdlib = { workspace = true }
-ed25519-dalek = { version = "2", features = ["rand_core"] }
-hex = "0.4"
-rand_core = "0.6"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+ed25519-dalek = { version = "=2.2.0", features = ["rand_core"] }
+hex = "=0.4.3"
+rand_core = "=0.6.4"
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.149"
 
 [lib]
 crate-type = ["cdylib"]

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -16,6 +16,17 @@ import {
   ResponseHandler,
 } from "@freenetorg/freenet-stdlib";
 import { Post } from "./types";
+import { runMigrations, type MigrationRunnerDeps } from "./migrations/run";
+import {
+  LocalStorageMigrationStateStore,
+  type MigrationStateStore,
+} from "./migrations/state-store";
+import {
+  CURRENT_POSTS_CODE_HASH,
+  LEGACY_POSTS_CODE_HASHES,
+  type ContractType,
+  type MigratableContract,
+} from "./migrations/legacy-hashes";
 
 // Contract post format (matches Rust contract)
 interface ContractPost {
@@ -74,6 +85,8 @@ export interface FreenetCallbacks {
   onStatusChange: (status: ConnectionStatus) => void;
   /** Optional: receives delegate responses forwarded from the node. */
   onDelegateResponse?: (response: DelegateResponse) => void;
+  /** Optional: one-line progress messages from the startup migration loop. */
+  onMigration?: (message: string) => void;
 }
 
 export class FreenetConnection {
@@ -85,6 +98,10 @@ export class FreenetConnection {
     name: string;
     handle: string;
   } | null = null;
+  private migrationStore: MigrationStateStore =
+    new LocalStorageMigrationStateStore();
+  /** True while the startup migration loop probes old contract keys. */
+  private migrating = false;
 
   constructor(callbacks: FreenetCallbacks) {
     this.callbacks = callbacks;
@@ -107,9 +124,7 @@ export class FreenetConnection {
       // fromInstanceId only sets instance — we need both for the node.
       // The published contract key (base58) decodes to 32 bytes that serve
       // as both instance ID and code hash (when no parameters are used).
-      const keyFromId = ContractKey.fromInstanceId(modelContract);
-      const instanceBytes = keyFromId.bytes();
-      this.contractKey = new ContractKey(instanceBytes, instanceBytes);
+      this.contractKey = this.deriveContractKey(modelContract);
       const wsUrl = new URL(`ws://${location.host}/v1/contract/command`);
 
       const handler: ResponseHandler = {
@@ -122,6 +137,9 @@ export class FreenetConnection {
           this.handleUpdateNotification(notification);
         },
         onContractNotFound: (_instanceId: Uint8Array) => {
+          // A migration probe against an old key that no longer exists is
+          // expected — the awaited get() rejects and is handled there.
+          if (this.migrating) return;
           console.warn("[freenet] Contract not found");
           this.callbacks.onStatusChange("error");
         },
@@ -135,8 +153,7 @@ export class FreenetConnection {
         onOpen: () => {
           console.log("[freenet] Connected to Freenet node");
           this.callbacks.onStatusChange("connected");
-          this.loadState();
-          this.subscribeToUpdates();
+          void this.startup();
         },
       };
       // Pass empty string as authToken to skip cookie reading (sandbox blocks it)
@@ -145,6 +162,117 @@ export class FreenetConnection {
       console.warn("[freenet] Connection failed:", e);
       this.callbacks.onStatusChange("error");
     }
+  }
+
+  /**
+   * Derive the node ContractKey from a base58 instance id. The published key
+   * decodes to 32 bytes that serve as both instance id and code hash when the
+   * contract uses no parameters.
+   */
+  private deriveContractKey(instanceId: string): ContractKey {
+    const keyFromId = ContractKey.fromInstanceId(instanceId);
+    const bytes = keyFromId.bytes();
+    return new ContractKey(bytes, bytes);
+  }
+
+  /** Run the migration loop, then load + subscribe to the current contract. */
+  private async startup(): Promise<void> {
+    await this.runStartupMigrations();
+    this.loadState();
+    this.subscribeToUpdates();
+  }
+
+  /**
+   * Detect a contract-hash bump since the last session and pull any state
+   * stranded under the old key into the current contract. Runs before
+   * subscribeToUpdates so the live feed reflects migrated state.
+   */
+  private async runStartupMigrations(): Promise<void> {
+    if (!this.api || !this.contractKey) return;
+
+    const log = (message: string) => {
+      console.log(message);
+      this.callbacks.onMigration?.(message);
+    };
+
+    const contracts: MigratableContract[] = [
+      {
+        type: "posts",
+        currentHash: CURRENT_POSTS_CODE_HASH,
+        legacyHashes: LEGACY_POSTS_CODE_HASHES,
+      },
+    ];
+
+    const deps: MigrationRunnerDeps = {
+      store: this.migrationStore,
+      getState: (type, candidateHash) =>
+        this.migrationGetState(type, candidateHash),
+      reinject: (type, state) => this.migrationReinject(type, state),
+      log,
+    };
+
+    this.migrating = true;
+    try {
+      await runMigrations(contracts, deps);
+    } catch (e) {
+      console.error("[migration] startup migration failed:", e);
+    } finally {
+      this.migrating = false;
+    }
+  }
+
+  /** GET the state stored under an old contract key; null if unavailable. */
+  private async migrationGetState(
+    _type: ContractType,
+    candidateHash: string,
+  ): Promise<unknown | null> {
+    if (!this.api) return null;
+    const key = this.deriveContractKey(candidateHash);
+    try {
+      const resp = await this.withTimeout(
+        this.api.get(new GetRequest(key, false)),
+        8000,
+      );
+      const json = new TextDecoder("utf8").decode(Uint8Array.from(resp.state));
+      return JSON.parse(json);
+    } catch (e) {
+      console.warn(`[migration] GET candidate ${candidateHash} failed:`, e);
+      return null;
+    }
+  }
+
+  /** Merge migrated state into the current contract via a delta update. */
+  private async migrationReinject(
+    type: ContractType,
+    state: unknown,
+  ): Promise<void> {
+    if (!this.api || !this.contractKey) return;
+    // Only posts is wired into the UI today; follows/likes land with #11/#13.
+    if (type !== "posts") return;
+    const posts = (state as PostsFeedState | null)?.posts;
+    if (!Array.isArray(posts) || posts.length === 0) return;
+    const deltaBytes = new TextEncoder().encode(JSON.stringify(posts));
+    const update = new UpdateData(
+      UpdateDataType.DeltaUpdate,
+      new DeltaUpdate(Array.from(deltaBytes)),
+    );
+    await this.api.update(new UpdateRequest(this.contractKey, update));
+  }
+
+  private withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timeout")), ms);
+      p.then(
+        (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      );
+    });
   }
 
   loadState(): void {
@@ -164,6 +292,11 @@ export class FreenetConnection {
   }
 
   private handleGetResponse(response: GetResponse): void {
+    // The startup migration loop issues GETs against old contract keys and
+    // consumes those responses via the awaited Promise returned by api.get().
+    // The same responses also reach this handler — skip them so old-version
+    // state never lands in the live feed.
+    if (this.migrating) return;
     try {
       const decoder = new TextDecoder("utf8");
       const stateJson = decoder.decode(Uint8Array.from(response.state));

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -102,6 +102,32 @@ function showSplash(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Migration toast — surfaces startup contract-migration progress.
+// ---------------------------------------------------------------------------
+let migrationToastTimer: ReturnType<typeof setTimeout> | null = null;
+
+function showMigrationToast(message: string): void {
+  let toast = document.querySelector<HTMLElement>(".migration-toast");
+  if (!toast) {
+    toast = document.createElement("div");
+    toast.className = "migration-toast";
+    toast.style.cssText =
+      "position:fixed;left:50%;bottom:24px;transform:translateX(-50%);" +
+      "z-index:1000;max-width:90vw;padding:8px 14px;border-radius:8px;" +
+      "background:var(--ink-1,#222);color:var(--paper,#fff);" +
+      "font-family:var(--font-mono,monospace);font-size:11px;" +
+      "box-shadow:0 4px 16px rgba(0,0,0,0.25);";
+    document.body.appendChild(toast);
+  }
+  toast.textContent = message.replace(/^\[migration\]\s*/, "Migrating: ");
+  if (migrationToastTimer) clearTimeout(migrationToastTimer);
+  migrationToastTimer = setTimeout(() => {
+    toast?.remove();
+    migrationToastTimer = null;
+  }, 4000);
+}
+
+// ---------------------------------------------------------------------------
 // Connection
 // ---------------------------------------------------------------------------
 const connection = new FreenetConnection({
@@ -132,6 +158,9 @@ const connection = new FreenetConnection({
         showOnboarding();
       }
     }
+  },
+  onMigration: (message: string) => {
+    showMigrationToast(message);
   },
   onDelegateResponse: (response: DelegateResponse) => {
     const payloads = parseDelegateResponse(response);

--- a/web/src/migrations/candidates.test.ts
+++ b/web/src/migrations/candidates.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildMigrationCandidates, selectMigrateFrom } from "./candidates";
+
+// Table tests mirror `migration_logic_tests` in freenet/mail
+// `ui/src/inbox.rs:1101`.
+
+describe("buildMigrationCandidates", () => {
+  it("returns the single prior hash when legacy is empty", () => {
+    expect(buildMigrationCandidates("h0", [])).toEqual(["h0"]);
+  });
+
+  it("skips entries at or before prior", () => {
+    expect(buildMigrationCandidates("h1", ["h0", "h1", "h2"])).toEqual(["h1", "h2"]);
+  });
+
+  it("walks the whole list when prior is absent", () => {
+    expect(buildMigrationCandidates("unknown", ["h0", "h1"])).toEqual([
+      "unknown",
+      "h0",
+      "h1",
+    ]);
+  });
+
+  it("emits no duplicate when prior is the last legacy entry", () => {
+    expect(buildMigrationCandidates("h1", ["h0", "h1"])).toEqual(["h1"]);
+  });
+});
+
+describe("selectMigrateFrom", () => {
+  it("returns null when prior matches current (no drift)", () => {
+    expect(selectMigrateFrom("cur", null, "cur")).toBeNull();
+  });
+
+  it("ignores pending when prior matches current", () => {
+    expect(selectMigrateFrom("cur", "stale", "cur")).toBeNull();
+  });
+
+  it("prefers pending over prior", () => {
+    expect(selectMigrateFrom("old", "older", "cur")).toBe("older");
+  });
+
+  it("falls back to prior when no pending", () => {
+    expect(selectMigrateFrom("old", null, "cur")).toBe("old");
+  });
+
+  it("uses pending when prior is absent", () => {
+    expect(selectMigrateFrom(null, "older", "cur")).toBe("older");
+  });
+
+  it("returns null on first observation", () => {
+    expect(selectMigrateFrom(null, null, "cur")).toBeNull();
+  });
+});

--- a/web/src/migrations/candidates.ts
+++ b/web/src/migrations/candidates.ts
@@ -1,0 +1,55 @@
+/**
+ * candidates.ts — pure, node-free migration helpers.
+ *
+ * Ported directly from freenet/mail `ui/src/inbox.rs`
+ * (`build_migration_candidates` at :78, `select_migrate_from` at :107).
+ * Kept free of any Freenet SDK / DOM coupling so the precedence rules and
+ * chain-build logic stay unit-testable without a node round-trip.
+ */
+
+/**
+ * Build the ordered list of code hashes to probe when migrating away from
+ * `priorHash`. Starts with `priorHash`, then every legacy entry that follows
+ * it (oldest → newest). If `priorHash` is not in `legacy`, walks the whole
+ * list. Never emits a duplicate of `priorHash`.
+ */
+export function buildMigrationCandidates(
+  priorHash: string,
+  legacy: readonly string[],
+): string[] {
+  const out: string[] = [priorHash];
+  const idx = legacy.indexOf(priorHash);
+  const startIdx = idx === -1 ? 0 : idx + 1;
+  for (const h of legacy.slice(startIdx)) {
+    if (h !== priorHash) {
+      out.push(h);
+    }
+  }
+  return out;
+}
+
+/**
+ * Decide which prior hash (if any) to migrate state from.
+ *
+ * Precedence (mirrors mail's `select_migrate_from`):
+ *   - `prior == current`        → None (already on the current version)
+ *   - a `pending` marker exists → migrate from it (crash-recovery retry)
+ *   - a `prior` hash exists     → migrate from it (drift just detected)
+ *   - nothing recorded          → None (first observation)
+ */
+export function selectMigrateFrom(
+  prior: string | null | undefined,
+  pending: string | null | undefined,
+  current: string,
+): string | null {
+  if (prior != null && prior === current) {
+    return null;
+  }
+  if (pending != null) {
+    return pending;
+  }
+  if (prior != null) {
+    return prior;
+  }
+  return null;
+}

--- a/web/src/migrations/legacy-hashes.test.ts
+++ b/web/src/migrations/legacy-hashes.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  MIGRATABLE_CONTRACTS,
+  LEGACY_FOLLOWS_CODE_HASHES,
+  LEGACY_LIKES_CODE_HASHES,
+  LEGACY_POSTS_CODE_HASHES,
+} from "./legacy-hashes";
+
+// Mirrors mail's `current_hash_not_in_legacy` (`ui/src/inbox.rs:1184`):
+// a contract's current hash must never appear in its own legacy list —
+// append it only AFTER bumping to a new hash.
+describe("legacy hash invariant", () => {
+  for (const contract of MIGRATABLE_CONTRACTS) {
+    it(`${contract.type}: current hash is not in its legacy list`, () => {
+      expect(contract.legacyHashes).not.toContain(contract.currentHash);
+    });
+  }
+
+  it("legacy lists contain no duplicates", () => {
+    for (const legacy of [
+      LEGACY_POSTS_CODE_HASHES,
+      LEGACY_FOLLOWS_CODE_HASHES,
+      LEGACY_LIKES_CODE_HASHES,
+    ]) {
+      expect(new Set(legacy).size).toBe(legacy.length);
+    }
+  });
+});

--- a/web/src/migrations/legacy-hashes.ts
+++ b/web/src/migrations/legacy-hashes.ts
@@ -1,0 +1,75 @@
+/**
+ * legacy-hashes.ts — per-contract code-hash registry for migrations.
+ *
+ * Each migratable contract carries an append-only list of the code hashes it
+ * has rotated through (oldest → newest). The current hash MUST NOT appear in
+ * its own legacy list — append it only AFTER bumping to a new hash. This
+ * invariant is enforced by `legacy-hashes.test.ts`.
+ *
+ * Mirrors freenet/mail's `LEGACY_INBOX_CODE_HASHES` / `LEGACY_TOKEN_RECORD_CODE_HASHES`
+ * (`ui/src/inbox.rs:66`, `ui/src/aft.rs:59`).
+ *
+ * See AGENTS.md → "Contract migration" for the bump recipe.
+ */
+
+export type ContractType = "posts" | "follows" | "likes";
+
+/**
+ * Sentinel emitted by `web/vite.config.ts` when a contract has not been built
+ * (dev / offline / CI). A sentinel current hash means the contract is not
+ * connected this session, so the migration loop skips it.
+ */
+export const DEV_NO_CONTRACT_HASH = "DEV_MODE_NO_CONTRACT_HASH";
+
+// --- Append-only legacy lists. Oldest → newest. Never reorder, never delete. ---
+
+export const LEGACY_POSTS_CODE_HASHES: readonly string[] = [];
+export const LEGACY_FOLLOWS_CODE_HASHES: readonly string[] = [];
+export const LEGACY_LIKES_CODE_HASHES: readonly string[] = [];
+
+// --- Current hashes, wired from the build-time injection in vite.config.ts. ---
+
+export const CURRENT_POSTS_CODE_HASH: string =
+  typeof __MODEL_CONTRACT__ !== "undefined"
+    ? __MODEL_CONTRACT__
+    : DEV_NO_CONTRACT_HASH;
+
+export const CURRENT_FOLLOWS_CODE_HASH: string =
+  typeof __FOLLOWS_CONTRACT__ !== "undefined"
+    ? __FOLLOWS_CONTRACT__
+    : DEV_NO_CONTRACT_HASH;
+
+export const CURRENT_LIKES_CODE_HASH: string =
+  typeof __LIKES_CONTRACT__ !== "undefined"
+    ? __LIKES_CONTRACT__
+    : DEV_NO_CONTRACT_HASH;
+
+export interface MigratableContract {
+  readonly type: ContractType;
+  readonly currentHash: string;
+  readonly legacyHashes: readonly string[];
+}
+
+/** Every contract type the migration system knows how to track. */
+export const MIGRATABLE_CONTRACTS: readonly MigratableContract[] = [
+  {
+    type: "posts",
+    currentHash: CURRENT_POSTS_CODE_HASH,
+    legacyHashes: LEGACY_POSTS_CODE_HASHES,
+  },
+  {
+    type: "follows",
+    currentHash: CURRENT_FOLLOWS_CODE_HASH,
+    legacyHashes: LEGACY_FOLLOWS_CODE_HASHES,
+  },
+  {
+    type: "likes",
+    currentHash: CURRENT_LIKES_CODE_HASH,
+    legacyHashes: LEGACY_LIKES_CODE_HASHES,
+  },
+];
+
+/** A built/connected contract carries a real hash, not the dev sentinel. */
+export function hasRealHash(hash: string): boolean {
+  return hash.length > 0 && hash !== DEV_NO_CONTRACT_HASH;
+}

--- a/web/src/migrations/run.test.ts
+++ b/web/src/migrations/run.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { runMigrations, type MigrationRunnerDeps } from "./run";
+import { LocalStorageMigrationStateStore } from "./state-store";
+import {
+  DEV_NO_CONTRACT_HASH,
+  type ContractType,
+  type MigratableContract,
+} from "./legacy-hashes";
+
+function postsContract(
+  currentHash: string,
+  legacyHashes: readonly string[] = [],
+): MigratableContract {
+  return { type: "posts", currentHash, legacyHashes };
+}
+
+function deps(overrides: Partial<MigrationRunnerDeps> = {}) {
+  const store = new LocalStorageMigrationStateStore(null);
+  const base = {
+    store,
+    getState: vi.fn(
+      (_type: ContractType, _hash: string): Promise<unknown | null> =>
+        Promise.resolve(null),
+    ),
+    reinject: vi.fn(
+      (_type: ContractType, _state: unknown): Promise<void> =>
+        Promise.resolve(),
+    ),
+  };
+  return { ...base, ...overrides, store };
+}
+
+describe("runMigrations", () => {
+  it("stamps a baseline on first observation without probing", async () => {
+    const d = deps();
+    await runMigrations([postsContract("cur")], d);
+    expect(d.getState).not.toHaveBeenCalled();
+    expect(d.reinject).not.toHaveBeenCalled();
+    expect(d.store.get("posts").recordedHash).toBe("cur");
+  });
+
+  it("does nothing when the recorded hash already matches current", async () => {
+    const d = deps();
+    d.store.setRecordedHash("posts", "cur");
+    await runMigrations([postsContract("cur")], d);
+    expect(d.getState).not.toHaveBeenCalled();
+  });
+
+  it("skips contracts that were not built this session", async () => {
+    const d = deps();
+    await runMigrations([postsContract(DEV_NO_CONTRACT_HASH)], d);
+    expect(d.getState).not.toHaveBeenCalled();
+    expect(d.store.get("posts").recordedHash).toBeNull();
+  });
+
+  it("migrates from the prior hash and clears pending on success", async () => {
+    const found = { posts: [{ id: "1" }] };
+    const getState = vi.fn(async () => found);
+    const reinject = vi.fn(async () => {});
+    const d = deps({ getState, reinject });
+    d.store.setRecordedHash("posts", "old");
+
+    await runMigrations([postsContract("cur")], d);
+
+    expect(getState).toHaveBeenCalledWith("posts", "old");
+    expect(reinject).toHaveBeenCalledWith("posts", found);
+    expect(d.store.get("posts")).toEqual({
+      recordedHash: "cur",
+      pendingMigrationFrom: null,
+    });
+  });
+
+  it("probes candidates oldest→newest until one yields state", async () => {
+    const getState = vi.fn(
+      (_type: ContractType, _hash: string): Promise<unknown | null> =>
+        Promise.resolve(null),
+    );
+    getState.mockResolvedValueOnce(null); // "old"
+    getState.mockResolvedValueOnce({ posts: [] }); // "h1"
+    const d = deps({ getState });
+    d.store.setRecordedHash("posts", "old");
+
+    await runMigrations([postsContract("cur", ["old", "h1"])], d);
+
+    expect(getState.mock.calls.map((c) => c[1])).toEqual(["old", "h1"]);
+  });
+
+  it("stamps current but keeps pending when no candidate resolves", async () => {
+    const d = deps({ getState: vi.fn(async () => null) });
+    d.store.setRecordedHash("posts", "old");
+
+    await runMigrations([postsContract("cur")], d);
+
+    expect(d.store.get("posts").recordedHash).toBe("cur");
+    expect(d.store.get("posts").pendingMigrationFrom).toBe("old");
+  });
+
+  it("recovers from a pending marker left by a crashed session", async () => {
+    const getState = vi.fn(
+      (_type: ContractType, _hash: string): Promise<unknown | null> =>
+        Promise.resolve({ posts: [] }),
+    );
+    const d = deps({ getState });
+    // Crash recovery: prior still old, pending records the in-flight source.
+    d.store.setRecordedHash("posts", "old");
+    d.store.setPendingMigrationFrom("posts", "older");
+
+    await runMigrations([postsContract("cur", ["older", "old"])], d);
+
+    // pending wins over prior as the migration source.
+    expect(getState.mock.calls[0][1]).toBe("older");
+  });
+});

--- a/web/src/migrations/run.ts
+++ b/web/src/migrations/run.ts
@@ -1,0 +1,117 @@
+/**
+ * run.ts — startup migration loop.
+ *
+ * Ports the per-identity loop from freenet/mail (`ui/src/api.rs:2680-3100`),
+ * collapsed to the global-contract case we have today. The Freenet SDK / DOM
+ * coupling is injected via `MigrationRunnerDeps` so this stays unit-testable
+ * with fakes (see `run.test.ts`).
+ *
+ * For each migratable contract:
+ *   1. `selectMigrateFrom(prior, pending, current)` decides if state drifted.
+ *   2. On drift, stamp the pending marker FIRST (crash mid-flow recovers next
+ *      session), then probe each candidate hash oldest→newest until one yields
+ *      state, and re-inject it under the current key.
+ *   3. Stamp the current hash regardless, so drift does not refire every
+ *      session even if no candidate resolved; clear the pending marker on a
+ *      successful re-inject.
+ *   4. First observation (nothing recorded): stamp the current hash as the
+ *      baseline so the next bump is detectable.
+ */
+
+import { buildMigrationCandidates, selectMigrateFrom } from "./candidates";
+import { hasRealHash, type ContractType, type MigratableContract } from "./legacy-hashes";
+import type { MigrationStateStore } from "./state-store";
+
+export interface MigrationRunnerDeps {
+  readonly store: MigrationStateStore;
+  /**
+   * GET the contract state stored under `candidateHash` for `type`. Returns
+   * the decoded state, or null if the candidate contract has no state on the
+   * node (not found / timeout / decode failure).
+   */
+  getState(type: ContractType, candidateHash: string): Promise<unknown | null>;
+  /** Re-inject migrated `state` into the current contract for `type`. */
+  reinject(type: ContractType, state: unknown): Promise<void>;
+  /** Optional progress sink (console + UI). */
+  log?(message: string): void;
+}
+
+function shorten(hash: string): string {
+  return hash.length > 12 ? `${hash.slice(0, 8)}…${hash.slice(-4)}` : hash;
+}
+
+export async function runMigrations(
+  contracts: readonly MigratableContract[],
+  deps: MigrationRunnerDeps,
+): Promise<void> {
+  for (const contract of contracts) {
+    await migrateContract(contract, deps);
+  }
+}
+
+async function migrateContract(
+  contract: MigratableContract,
+  deps: MigrationRunnerDeps,
+): Promise<void> {
+  const { type, currentHash, legacyHashes } = contract;
+  const log = deps.log ?? (() => {});
+
+  // Not built / not connected this session — nothing to track.
+  if (!hasRealHash(currentHash)) {
+    return;
+  }
+
+  const recorded = deps.store.get(type);
+  const migrateFrom = selectMigrateFrom(
+    recorded.recordedHash,
+    recorded.pendingMigrationFrom,
+    currentHash,
+  );
+
+  if (migrateFrom == null) {
+    // First observation: stamp the baseline so the next bump is detectable.
+    if (recorded.recordedHash == null) {
+      deps.store.setRecordedHash(type, currentHash);
+      log(`[migration] ${type}: first observation, baseline ${shorten(currentHash)}`);
+    }
+    return;
+  }
+
+  log(
+    `[migration] ${type}: drift detected, migrating from ${shorten(migrateFrom)} → ${shorten(currentHash)}`,
+  );
+
+  // Stamp the pending marker FIRST so a crash mid-flow recovers next session.
+  deps.store.setPendingMigrationFrom(type, migrateFrom);
+
+  const candidates = buildMigrationCandidates(migrateFrom, legacyHashes);
+  let migrated = false;
+  for (const candidate of candidates) {
+    if (candidate === currentHash) {
+      continue; // never probe the current key as if it were old state
+    }
+    log(`[migration] ${type}: probing candidate ${shorten(candidate)}`);
+    let state: unknown | null = null;
+    try {
+      state = await deps.getState(type, candidate);
+    } catch (e) {
+      log(`[migration] ${type}: candidate ${shorten(candidate)} GET failed: ${e}`);
+    }
+    if (state != null) {
+      log(`[migration] ${type}: re-injecting state from ${shorten(candidate)} under ${shorten(currentHash)}`);
+      await deps.reinject(type, state);
+      migrated = true;
+      break;
+    }
+  }
+
+  // Stamp current regardless so drift does not refire each session even if no
+  // candidate resolved (mirrors mail's UpdateInboxWasmHash after dispatch).
+  deps.store.setRecordedHash(type, currentHash);
+  if (migrated) {
+    deps.store.setPendingMigrationFrom(type, null);
+    log(`[migration] ${type}: migration complete`);
+  } else {
+    log(`[migration] ${type}: no candidate state found`);
+  }
+}

--- a/web/src/migrations/state-store.test.ts
+++ b/web/src/migrations/state-store.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { LocalStorageMigrationStateStore } from "./state-store";
+
+class FakeStorage implements Storage {
+  private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+describe("LocalStorageMigrationStateStore", () => {
+  let storage: FakeStorage;
+  let store: LocalStorageMigrationStateStore;
+
+  beforeEach(() => {
+    storage = new FakeStorage();
+    store = new LocalStorageMigrationStateStore(storage);
+  });
+
+  it("returns empty state for an unseen contract", () => {
+    expect(store.get("posts")).toEqual({
+      recordedHash: null,
+      pendingMigrationFrom: null,
+    });
+  });
+
+  it("persists the recorded hash under a versioned key", () => {
+    store.setRecordedHash("posts", "h1");
+    expect(store.get("posts").recordedHash).toBe("h1");
+    expect(storage.getItem("raven:migration:posts:v1")).toContain("h1");
+  });
+
+  it("preserves the pending marker when the recorded hash changes", () => {
+    store.setPendingMigrationFrom("posts", "old");
+    store.setRecordedHash("posts", "new");
+    expect(store.get("posts")).toEqual({
+      recordedHash: "new",
+      pendingMigrationFrom: "old",
+    });
+  });
+
+  it("clears the pending marker independently", () => {
+    store.setPendingMigrationFrom("posts", "old");
+    store.setPendingMigrationFrom("posts", null);
+    expect(store.get("posts").pendingMigrationFrom).toBeNull();
+  });
+
+  it("keeps contract types isolated", () => {
+    store.setRecordedHash("posts", "p");
+    store.setRecordedHash("follows", "f");
+    expect(store.get("posts").recordedHash).toBe("p");
+    expect(store.get("follows").recordedHash).toBe("f");
+  });
+
+  it("falls back to in-memory when no storage is available", () => {
+    const memStore = new LocalStorageMigrationStateStore(null);
+    memStore.setRecordedHash("likes", "x");
+    expect(memStore.get("likes").recordedHash).toBe("x");
+  });
+});

--- a/web/src/migrations/state-store.ts
+++ b/web/src/migrations/state-store.ts
@@ -1,0 +1,105 @@
+/**
+ * state-store.ts — recorded migration state, persisted per contract type.
+ *
+ * For the global contracts we have today (posts/follows/likes), each contract
+ * type records the hash it was last observed under plus an optional pending
+ * marker for crash-recovery. This mirrors the per-identity `AliasInfo` fields
+ * mail keeps on its identity delegate (`inbox_wasm_hash` +
+ * `pending_migration_from`).
+ *
+ * Everything lives behind the `MigrationStateStore` interface so the
+ * per-identity path (issue #11) can swap in a delegate-backed store later
+ * without touching the migration loop.
+ */
+
+import type { ContractType } from "./legacy-hashes";
+
+export interface RecordedMigrationState {
+  /** Hash this contract's state was last observed under (null = never seen). */
+  readonly recordedHash: string | null;
+  /** Retry marker: a prior hash a migration was started from but not finished. */
+  readonly pendingMigrationFrom: string | null;
+}
+
+const EMPTY: RecordedMigrationState = {
+  recordedHash: null,
+  pendingMigrationFrom: null,
+};
+
+export interface MigrationStateStore {
+  get(type: ContractType): RecordedMigrationState;
+  setRecordedHash(type: ContractType, hash: string): void;
+  setPendingMigrationFrom(type: ContractType, priorHash: string | null): void;
+}
+
+/** Versioned localStorage key, e.g. `raven:migration:posts:v1`. */
+function storageKey(type: ContractType): string {
+  return `raven:migration:${type}:v1`;
+}
+
+/**
+ * localStorage-backed store for the global-contract era. Falls back to an
+ * in-memory map when localStorage is unavailable (SSR, private mode, tests).
+ */
+export class LocalStorageMigrationStateStore implements MigrationStateStore {
+  private readonly memory = new Map<string, RecordedMigrationState>();
+  private readonly storage: Storage | null;
+
+  constructor(storage: Storage | null = defaultStorage()) {
+    this.storage = storage;
+  }
+
+  get(type: ContractType): RecordedMigrationState {
+    const key = storageKey(type);
+    if (this.storage) {
+      const raw = this.storage.getItem(key);
+      if (raw == null) return EMPTY;
+      try {
+        const parsed = JSON.parse(raw) as Partial<RecordedMigrationState>;
+        return {
+          recordedHash: parsed.recordedHash ?? null,
+          pendingMigrationFrom: parsed.pendingMigrationFrom ?? null,
+        };
+      } catch {
+        return EMPTY;
+      }
+    }
+    return this.memory.get(key) ?? EMPTY;
+  }
+
+  setRecordedHash(type: ContractType, hash: string): void {
+    const next: RecordedMigrationState = {
+      ...this.get(type),
+      recordedHash: hash,
+    };
+    this.write(type, next);
+  }
+
+  setPendingMigrationFrom(type: ContractType, priorHash: string | null): void {
+    const next: RecordedMigrationState = {
+      ...this.get(type),
+      pendingMigrationFrom: priorHash,
+    };
+    this.write(type, next);
+  }
+
+  private write(type: ContractType, state: RecordedMigrationState): void {
+    const key = storageKey(type);
+    if (this.storage) {
+      this.storage.setItem(key, JSON.stringify(state));
+    } else {
+      this.memory.set(key, state);
+    }
+  }
+}
+
+function defaultStorage(): Storage | null {
+  try {
+    if (typeof localStorage !== "undefined") {
+      return localStorage;
+    }
+  } catch {
+    // Accessing localStorage can throw in sandboxed iframes.
+  }
+  return null;
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
 
 declare const __MODEL_CONTRACT__: string;
+declare const __FOLLOWS_CONTRACT__: string;
+declare const __LIKES_CONTRACT__: string;
 declare const __DELEGATE_KEY__: string;
 declare const __DELEGATE_KEY_BYTES__: number[];
 declare const __DELEGATE_CODE_HASH_BYTES__: number[];

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,6 +11,8 @@ function readFileOrDefault(filename: string, fallback: string): string {
 export default defineConfig({
   define: {
     __MODEL_CONTRACT__: JSON.stringify(readFileOrDefault("model_code_hash.txt", "DEV_MODE_NO_CONTRACT_HASH")),
+    __FOLLOWS_CONTRACT__: JSON.stringify(readFileOrDefault("follows_contract_id.txt", "DEV_MODE_NO_CONTRACT_HASH")),
+    __LIKES_CONTRACT__: JSON.stringify(readFileOrDefault("likes_contract_id.txt", "DEV_MODE_NO_CONTRACT_HASH")),
     __DELEGATE_KEY__: JSON.stringify(readFileOrDefault("delegate_key.txt", "")),
     __DELEGATE_KEY_BYTES__: readFileOrDefault("delegate_key_bytes.json", "[]"),
     __DELEGATE_CODE_HASH_BYTES__: readFileOrDefault("delegate_code_hash_bytes.json", "[]"),


### PR DESCRIPTION
## Summary

Implements the contract migration foundation from #20, so we can bump contract WASM hashes without stranding existing user state — a prerequisite for the #8 schema work (#11/#12/#13).

- **Schema tolerance:** `#[serde(default, skip_serializing_if = …)]` guards on `PostsFeed`/`Post`, `FollowGraph`, and `LikeGraph`, each with a `decodes_old_shape_state` test (old-shape JSON + unknown forward-compat fields both decode).
- **`web/src/migrations/`** (new):
  - `candidates.ts` — pure `buildMigrationCandidates` / `selectMigrateFrom`, ported from `freenet/mail` `ui/src/inbox.rs`.
  - `legacy-hashes.ts` — append-only `LEGACY_{POSTS,FOLLOWS,LIKES}_CODE_HASHES` + `CURRENT_*` constants wired from the build-time injection + a `MIGRATABLE_CONTRACTS` registry.
  - `state-store.ts` — `MigrationStateStore` interface, localStorage-backed under versioned `raven:migration:<type>:v1` keys (a delegate-backed store swaps in later for #11).
  - `run.ts` — the startup loop: stamp-pending-first crash recovery, candidate chain, re-inject, baseline stamp.
- **Wiring:** `FreenetConnection.connect` runs the migration loop before `subscribeToUpdates` — detects a hash bump, GETs each candidate old key, re-injects state under the current key via a delta update (fits the CRDT-merge contracts), records the baseline, and logs each step. Progress surfaces as a one-line toast. The contract-not-found path is guarded so benign old-key probes don't flip the UI to error.
- **Build isolation:** exact `=x.y.z` pins on every WASM-affecting dep across the three contracts + identity delegate + the workspace `freenet-stdlib` entry (`Cargo.lock` unchanged).
- **Docs:** AGENTS.md gains a "Contract migration" section — schema-tolerance policy, build isolation, bump recipe, helper pointers.

## Test plan

- [x] `cargo test` on posts/follows/likes (incl. new `decodes_old_shape_state`)
- [x] `cargo clippy` + `cargo fmt --check` on the touched crates
- [x] `cargo check` confirms the exact pins resolve (`Cargo.lock` unchanged)
- [x] Vitest: 27 cases — `buildMigrationCandidates` (prior in/not-in legacy), `selectMigrateFrom` (4 precedence cases + `prior == current` short-circuit), the current-hash-not-in-legacy invariant, the state store, and the startup loop
- [x] `tsc --noEmit` + offline `vite build`
- [ ] **Manual end-to-end** (force a hash bump, append old hash to legacy list, reload, confirm old state appears under the new key) — needs a running Freenet node + real contract builds; not run in CI

## Notes / follow-ups

- `rust-toolchain.toml` is `channel = "stable"` (not version-pinned). The exact dep pins + committed lockfile cover most build isolation, but floating stable could in principle shift codegen. Left untouched to avoid pinning a toolchain CI may not have — flagging for a decision.
- The runtime loop only migrates **posts** today (the only contract wired into the UI). The follows/likes registry entries, `CURRENT_*` constants, and Makefile contract-id injection are in place for when #11/#13 connect them.

Closes #20

https://claude.ai/code/session_013qJFtemg5G89Npeb5G5gzs

---
_Generated by [Claude Code](https://claude.ai/code/session_013qJFtemg5G89Npeb5G5gzs)_