### PR TITLE
test: integration tests for user + thread shards (multi-replica sync)

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -206,9 +206,10 @@ script_runner = "bash"
 script = '''
 set -euo pipefail
 ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
-cargo test -p freenet-microblogging-posts
-cargo test -p freenet-microblogging-follows
-cargo test -p freenet-microblogging-likes
+# Whole workspace so every contract, the common crate, and the identity delegate
+# are exercised — not a hand-maintained subset (the user/thread shards and the
+# delegate were previously omitted here and only ran in ad-hoc cargo test calls).
+cargo test --workspace
 cd "$ROOT/web" && npm test
 '''
 

--- a/contracts/thread-shard/src/lib.rs
+++ b/contracts/thread-shard/src/lib.rs
@@ -883,3 +883,328 @@ mod test {
         assert!(forward.replies.is_empty());
     }
 }
+
+/// Integration tests: drive the full `ContractInterface` (validate / update /
+/// summarize / get_state_delta) through multi-replica and multi-author scenarios
+/// — the layer above the per-function unit tests. The key scenario is **two
+/// replicas reconciling via the real sync protocol** (`summarize_state` →
+/// `get_state_delta` → `update_state`), which the unit tests do not exercise.
+///
+/// These still call the contract as a Rust library (not compiled WASM in a
+/// node); true WASM-in-node e2e is a separate, heavier tier (see the
+/// `freenet:linux-test` skill). What is new here vs. the unit tests: real
+/// multi-party ML-DSA-65 keys, the summarize/delta sync path, and cross-shard
+/// consistency between a post and its thread.
+#[cfg(test)]
+mod integration {
+    use super::*;
+    use freenet_microblogging_common::thread::{LikeRecord, QuoteRef};
+    use ml_dsa::signature::{Keypair, Signer};
+    use ml_dsa::{KeyGen, MlDsa65, Signature};
+
+    const ROOT: &str = "integration_root_post_address";
+
+    fn params() -> Parameters<'static> {
+        Parameters::from(ROOT.as_bytes().to_vec())
+    }
+
+    fn state_of(shard: &ThreadShard) -> State<'static> {
+        State::from(serde_json::to_vec(shard).unwrap())
+    }
+
+    fn decode(state: State<'static>) -> ThreadShard {
+        serde_json::from_slice(state.as_ref()).unwrap()
+    }
+
+    /// A reply to ROOT by the author with `seed`.
+    fn reply(seed: [u8; 32], content: &str, ts: u64) -> Post {
+        let sk = MlDsa65::from_seed(&seed.into());
+        let mut p = Post {
+            id: String::new(),
+            author_pubkey: hex::encode(sk.verifying_key().encode()),
+            author_name: "Author".into(),
+            author_handle: "@author".into(),
+            content: content.into(),
+            timestamp: ts,
+            reply_to: ROOT.into(),
+            signature: None,
+        };
+        p.id = p.compute_id();
+        let sig: Signature<MlDsa65> = sk.sign(&p.signing_payload());
+        p.signature = Some(hex::encode(sig.encode()));
+        p
+    }
+
+    fn like(seed: [u8; 32], seq: u64, liked: bool) -> LikeRecord {
+        let sk = MlDsa65::from_seed(&seed.into());
+        let mut r = LikeRecord {
+            signer_pubkey: hex::encode(sk.verifying_key().encode()),
+            seq,
+            liked,
+            writer_cert: None,
+            signature: None,
+        };
+        let sig: Signature<MlDsa65> = sk.sign(&r.signing_payload(ROOT));
+        r.signature = Some(hex::encode(sig.encode()));
+        r
+    }
+
+    fn quote(seed: [u8; 32], qid: &str) -> QuoteRef {
+        let sk = MlDsa65::from_seed(&seed.into());
+        let mut q = QuoteRef {
+            signer_pubkey: hex::encode(sk.verifying_key().encode()),
+            quote_post_id: qid.into(),
+            writer_cert: None,
+            signature: None,
+        };
+        let sig: Signature<MlDsa65> = sk.sign(&q.signing_payload(ROOT));
+        q.signature = Some(hex::encode(sig.encode()));
+        q
+    }
+
+    /// Apply a batch of deltas to a replica, returning its new state — the
+    /// contract's own `update_state`, exactly as a node would call it.
+    fn apply(shard: &ThreadShard, items: Vec<UpdateData<'static>>) -> ThreadShard {
+        let res = ThreadShard::update_state(params(), state_of(shard), items).unwrap();
+        decode(res.unwrap_valid())
+    }
+
+    fn delta(d: &ThreadDelta) -> UpdateData<'static> {
+        UpdateData::Delta(StateDelta::from(serde_json::to_vec(d).unwrap()))
+    }
+
+    /// One directional sync step, faithful to the node protocol: `dst` summarizes
+    /// what it has, `src` computes the delta of what `dst` is missing, `dst`
+    /// applies it. Returns `dst`'s new state. Every state must stay valid.
+    fn sync_into(dst: &ThreadShard, src: &ThreadShard) -> ThreadShard {
+        // dst is valid before syncing.
+        assert!(matches!(
+            ThreadShard::validate_state(params(), state_of(dst), RelatedContracts::new()).unwrap(),
+            ValidateResult::Valid
+        ));
+        let summary = ThreadShard::summarize_state(params(), state_of(dst)).unwrap();
+        let d = ThreadShard::get_state_delta(params(), state_of(src), summary).unwrap();
+        let merged = apply(
+            dst,
+            vec![UpdateData::Delta(StateDelta::from(d.into_bytes().to_vec()))],
+        );
+        // dst stays valid after syncing.
+        assert!(matches!(
+            ThreadShard::validate_state(params(), state_of(&merged), RelatedContracts::new())
+                .unwrap(),
+            ValidateResult::Valid
+        ));
+        merged
+    }
+
+    /// Full bidirectional reconcile: sync each way once. For these state sizes a
+    /// single round each direction converges (the delta carries everything the
+    /// peer lacks). Returns `(a', b')`, which must be equal.
+    fn reconcile(a: &ThreadShard, b: &ThreadShard) -> (ThreadShard, ThreadShard) {
+        let a2 = sync_into(a, b);
+        let b2 = sync_into(b, a);
+        (a2, b2)
+    }
+
+    fn canonical(shard: &ThreadShard) -> Vec<u8> {
+        serde_json::to_vec(shard).unwrap()
+    }
+
+    #[test]
+    fn two_replicas_converge_over_sync_protocol() {
+        // A and B each see a disjoint set of writes from different authors, then
+        // reconcile via summarize/get_state_delta/update_state. They must reach
+        // byte-identical state — exercising the real sync path, not direct merge.
+        let empty = ThreadShard::default();
+
+        let a = apply(
+            &empty,
+            vec![
+                delta(&ThreadDelta::Replies(vec![reply([1; 32], "a-reply", 100)])),
+                delta(&ThreadDelta::Likes(vec![like([2; 32], 1, true)])),
+                delta(&ThreadDelta::Quotes(vec![quote([3; 32], "qa")])),
+            ],
+        );
+        let b = apply(
+            &empty,
+            vec![
+                delta(&ThreadDelta::Replies(vec![reply([4; 32], "b-reply", 200)])),
+                delta(&ThreadDelta::Likes(vec![like([5; 32], 1, true)])),
+            ],
+        );
+
+        let (a2, b2) = reconcile(&a, &b);
+        assert_eq!(canonical(&a2), canonical(&b2), "replicas must converge");
+        // Union of all writes present on both.
+        assert_eq!(a2.replies.len(), 2);
+        assert_eq!(a2.likes.len(), 2);
+        assert_eq!(a2.quotes.len(), 1);
+    }
+
+    #[test]
+    fn concurrent_like_unlike_converges_over_sync() {
+        // Same liker, equal seq, opposite intents on the two replicas — the
+        // hardest convergence case. Over the sync protocol both must settle on
+        // the unlike (equal-seq tie-break), in either reconcile direction.
+        let empty = ThreadShard::default();
+        let a = apply(
+            &empty,
+            vec![delta(&ThreadDelta::Likes(vec![like([7; 32], 5, true)]))],
+        );
+        let b = apply(
+            &empty,
+            vec![delta(&ThreadDelta::Likes(vec![like([7; 32], 5, false)]))],
+        );
+
+        let (a2, b2) = reconcile(&a, &b);
+        assert_eq!(canonical(&a2), canonical(&b2));
+        let signer = hex::encode(
+            MlDsa65::from_seed(&[7u8; 32].into())
+                .verifying_key()
+                .encode(),
+        );
+        assert!(!a2.likes[&signer].liked, "equal-seq unlike wins after sync");
+
+        // And the reverse reconcile order yields the same fixed point.
+        let (b3, a3) = reconcile(&b, &a);
+        assert_eq!(canonical(&a3), canonical(&b3));
+        assert!(!a3.likes[&signer].liked);
+    }
+
+    #[test]
+    fn higher_seq_like_propagates_over_sync() {
+        // A has an old like (seq 1, liked); B has the same liker's newer unlike
+        // (seq 2). After sync both hold the unlike — the summary carries (seq,
+        // liked) so get_state_delta ships the newer record.
+        let empty = ThreadShard::default();
+        let a = apply(
+            &empty,
+            vec![delta(&ThreadDelta::Likes(vec![like([8; 32], 1, true)]))],
+        );
+        let b = apply(
+            &empty,
+            vec![delta(&ThreadDelta::Likes(vec![like([8; 32], 2, false)]))],
+        );
+        let signer = hex::encode(
+            MlDsa65::from_seed(&[8u8; 32].into())
+                .verifying_key()
+                .encode(),
+        );
+
+        let (a2, b2) = reconcile(&a, &b);
+        assert_eq!(canonical(&a2), canonical(&b2));
+        assert_eq!(a2.likes[&signer].seq, 2);
+        assert!(!a2.likes[&signer].liked);
+    }
+
+    #[test]
+    fn forged_like_does_not_propagate_over_sync() {
+        // A holds a forged (unsigned) like in its state. When B syncs from A, the
+        // forged like rides in the delta but B's update_state re-verifies and
+        // drops it — a malicious replica cannot inject a like into an honest one.
+        let victim = hex::encode(
+            MlDsa65::from_seed(&[9u8; 32].into())
+                .verifying_key()
+                .encode(),
+        );
+        let mut malicious = ThreadShard::default();
+        malicious.likes.insert(
+            victim.clone(),
+            LikeRecord {
+                signer_pubkey: victim.clone(),
+                seq: 1,
+                liked: true,
+                writer_cert: None,
+                signature: None, // forged
+            },
+        );
+        // (A malicious peer's own state need not be valid; we only care what an
+        // honest peer accepts from it.)
+        let honest = ThreadShard::default();
+        let synced = sync_into(&honest, &malicious);
+        assert!(
+            synced.likes.is_empty(),
+            "honest replica must reject forged like over sync"
+        );
+    }
+
+    #[test]
+    fn cross_shard_post_and_reply_use_consistent_keys() {
+        // A post authored on a user shard and a reply to it on the thread shard
+        // are both `common::post::Post`s signed by their authors with the single
+        // trusted encoder. The thread is keyed by the root post's content id, and
+        // a reply's reply_to must equal that id. This checks the cross-shard
+        // contract: the thread param is exactly the user-shard post's id, and a
+        // reply bound to it is accepted while one bound to a different id is not.
+        let author = [10u8; 32];
+        let sk = MlDsa65::from_seed(&author.into());
+        // The "root" post as it would live on the author's user shard.
+        let mut root_post = Post {
+            id: String::new(),
+            author_pubkey: hex::encode(sk.verifying_key().encode()),
+            author_name: "Root".into(),
+            author_handle: "@root".into(),
+            content: "the original post".into(),
+            timestamp: 1_000,
+            reply_to: String::new(),
+            signature: None,
+        };
+        root_post.id = root_post.compute_id();
+        let sig: Signature<MlDsa65> = sk.sign(&root_post.signing_payload());
+        root_post.signature = Some(hex::encode(sig.encode()));
+        assert_eq!(root_post.verify(), Ok(()));
+
+        // The thread shard for this post is parameterized by its content id.
+        let thread_params = Parameters::from(root_post.id.as_bytes().to_vec());
+
+        // A reply bound to that id (by a different author) is accepted.
+        let replier = [11u8; 32];
+        let rsk = MlDsa65::from_seed(&replier.into());
+        let mut good_reply = Post {
+            id: String::new(),
+            author_pubkey: hex::encode(rsk.verifying_key().encode()),
+            author_name: "Replier".into(),
+            author_handle: "@replier".into(),
+            content: "good reply".into(),
+            timestamp: 1_001,
+            reply_to: root_post.id.clone(),
+            signature: None,
+        };
+        good_reply.id = good_reply.compute_id();
+        let rsig: Signature<MlDsa65> = rsk.sign(&good_reply.signing_payload());
+        good_reply.signature = Some(hex::encode(rsig.encode()));
+
+        let res = ThreadShard::update_state(
+            thread_params.clone(),
+            State::from(serde_json::to_vec(&ThreadShard::default()).unwrap()),
+            vec![UpdateData::Delta(StateDelta::from(
+                serde_json::to_vec(&ThreadDelta::Replies(vec![good_reply.clone()])).unwrap(),
+            ))],
+        )
+        .unwrap();
+        let out: ThreadShard = serde_json::from_slice(res.unwrap_valid().as_ref()).unwrap();
+        assert_eq!(
+            out.replies.len(),
+            1,
+            "reply bound to the root id is accepted"
+        );
+        assert!(out.replies.contains_key(&good_reply.id));
+
+        // The same reply offered to the WRONG thread (different root param) is
+        // rejected — its signed reply_to no longer matches that thread's root.
+        let wrong_params = Parameters::from(b"some_other_root_id".to_vec());
+        let res2 = ThreadShard::update_state(
+            wrong_params,
+            State::from(serde_json::to_vec(&ThreadShard::default()).unwrap()),
+            vec![UpdateData::Delta(StateDelta::from(
+                serde_json::to_vec(&ThreadDelta::Replies(vec![good_reply])).unwrap(),
+            ))],
+        )
+        .unwrap();
+        let out2: ThreadShard = serde_json::from_slice(res2.unwrap_valid().as_ref()).unwrap();
+        assert!(
+            out2.replies.is_empty(),
+            "reply must not land on the wrong thread"
+        );
+    }
+}

--- a/contracts/user-shard/src/lib.rs
+++ b/contracts/user-shard/src/lib.rs
@@ -1119,3 +1119,275 @@ mod test {
         assert!(empty.follows.is_empty());
     }
 }
+
+/// Integration tests: drive the full `ContractInterface` through multi-replica
+/// reconciliation via the real sync protocol (`summarize_state` →
+/// `get_state_delta` → `update_state`) across all three owner-writes surfaces
+/// (posts, profile, follows). This is the layer above the per-function unit
+/// tests; what is new is the summarize/delta sync path and the validate-after-
+/// merge invariant, with real ML-DSA-65 owner keys.
+///
+/// Still a Rust-library drive of the contract, not compiled WASM in a node
+/// (that e2e tier is separate — see the `freenet:linux-test` skill).
+#[cfg(test)]
+mod integration {
+    use super::*;
+    use freenet_microblogging_common::signed_op::Profile;
+    use ml_dsa::signature::{Keypair, Signer};
+    use ml_dsa::{KeyGen, MlDsa65};
+
+    // The owner of the shard under test. Posts/ops the owner signs are accepted;
+    // a different key is rejected (owner-writes). One owner per shard instance.
+    const OWNER: [u8; 32] = [42u8; 32];
+
+    fn params() -> Parameters<'static> {
+        let sk = MlDsa65::from_seed(&OWNER.into());
+        Parameters::from(sk.verifying_key().encode().to_vec())
+    }
+
+    fn signed_post(content: &str, ts: u64) -> Post {
+        let sk = MlDsa65::from_seed(&OWNER.into());
+        let mut p = Post {
+            id: String::new(),
+            author_pubkey: hex::encode(sk.verifying_key().encode()),
+            author_name: "Owner".into(),
+            author_handle: "@owner".into(),
+            content: content.into(),
+            timestamp: ts,
+            reply_to: String::new(),
+            signature: None,
+        };
+        p.id = p.compute_id();
+        let sig: ml_dsa::Signature<MlDsa65> = sk.sign(&p.signing_payload());
+        p.signature = Some(hex::encode(sig.encode()));
+        p
+    }
+
+    fn op(op_type: OpType, payload: Vec<u8>, seq: u64) -> SignedOp {
+        let sk = MlDsa65::from_seed(&OWNER.into());
+        let mut o = SignedOp {
+            op_type,
+            payload,
+            seq,
+            signer_pubkey: hex::encode(sk.verifying_key().encode()),
+            signature: None,
+        };
+        let sig: ml_dsa::Signature<MlDsa65> = sk.sign(&o.signing_payload(USER_SHARD_CONTEXT));
+        o.signature = Some(hex::encode(sig.encode()));
+        o
+    }
+
+    fn profile_op(p: &Profile, seq: u64) -> SignedOp {
+        op(OpType::Profile, serde_json::to_vec(p).unwrap(), seq)
+    }
+
+    fn follow_op(targets: &[&str], follow: bool, seq: u64) -> SignedOp {
+        let targets: Vec<String> = targets.iter().map(|s| s.to_string()).collect();
+        op(
+            if follow {
+                OpType::Follow
+            } else {
+                OpType::Unfollow
+            },
+            serde_json::to_vec(&targets).unwrap(),
+            seq,
+        )
+    }
+
+    fn state_of(shard: &UserShard) -> State<'static> {
+        State::from(serde_json::to_vec(shard).unwrap())
+    }
+
+    fn decode(state: State<'static>) -> UserShard {
+        serde_json::from_slice(state.as_ref()).unwrap()
+    }
+
+    fn apply(shard: &UserShard, items: Vec<ShardDelta>) -> UserShard {
+        let deltas: Vec<UpdateData> = items
+            .into_iter()
+            .map(|d| UpdateData::Delta(StateDelta::from(serde_json::to_vec(&d).unwrap())))
+            .collect();
+        let res = UserShard::update_state(params(), state_of(shard), deltas).unwrap();
+        decode(res.unwrap_valid())
+    }
+
+    fn validate(shard: &UserShard) -> bool {
+        matches!(
+            UserShard::validate_state(params(), state_of(shard), RelatedContracts::new()).unwrap(),
+            ValidateResult::Valid
+        )
+    }
+
+    /// One directional sync step, faithful to the node protocol: `dst` summarizes,
+    /// `src` computes the delta of what `dst` lacks, `dst` applies it. Both states
+    /// must stay valid.
+    fn sync_into(dst: &UserShard, src: &UserShard) -> UserShard {
+        assert!(validate(dst));
+        let summary = UserShard::summarize_state(params(), state_of(dst)).unwrap();
+        let d = UserShard::get_state_delta(params(), state_of(src), summary).unwrap();
+        let res = UserShard::update_state(
+            params(),
+            state_of(dst),
+            vec![UpdateData::Delta(StateDelta::from(d.into_bytes().to_vec()))],
+        )
+        .unwrap();
+        let merged = decode(res.unwrap_valid());
+        assert!(validate(&merged));
+        merged
+    }
+
+    /// Bidirectional reconcile (one round each way). For these state sizes a
+    /// single round each direction converges. Returns `(a', b')`, must be equal.
+    fn reconcile(a: &UserShard, b: &UserShard) -> (UserShard, UserShard) {
+        let a2 = sync_into(a, b);
+        let b2 = sync_into(b, a);
+        (a2, b2)
+    }
+
+    fn canonical(shard: &UserShard) -> Vec<u8> {
+        serde_json::to_vec(shard).unwrap()
+    }
+
+    #[test]
+    fn two_replicas_converge_all_surfaces_over_sync() {
+        // A and B each see disjoint owner writes across posts, profile, and
+        // follows, then reconcile via the sync protocol. They must converge.
+        let empty = UserShard::default();
+        let prof_a = Profile {
+            display_name: "A".into(),
+            handle: "@a".into(),
+            bio: "".into(),
+            avatar: "".into(),
+        };
+        let prof_b = Profile {
+            display_name: "B".into(),
+            handle: "@b".into(),
+            bio: "bio".into(),
+            avatar: "red".into(),
+        };
+
+        let a = apply(
+            &empty,
+            vec![
+                ShardDelta::Posts(vec![signed_post("post-1", 100)]),
+                ShardDelta::Op(profile_op(&prof_a, 1)),
+                ShardDelta::Op(follow_op(&["aa", "bb"], true, 1)),
+            ],
+        );
+        // B has a newer profile (seq 2 wins) and a different post + follow edit.
+        let b = apply(
+            &empty,
+            vec![
+                ShardDelta::Posts(vec![signed_post("post-2", 200)]),
+                ShardDelta::Op(profile_op(&prof_b, 2)),
+                ShardDelta::Op(follow_op(&["cc"], true, 1)),
+            ],
+        );
+
+        let (a2, b2) = reconcile(&a, &b);
+        assert_eq!(canonical(&a2), canonical(&b2), "replicas must converge");
+        assert_eq!(a2.posts.len(), 2, "both posts present");
+        // Profile LWW: seq 2 (B's) wins on both.
+        assert_eq!(a2.profile.as_ref().unwrap().seq, 2);
+        assert_eq!(a2.profile.as_ref().unwrap().profile.display_name, "B");
+        // Follows union of the followed keys.
+        assert!(a2.follows.get("aa").map(|f| f.following).unwrap_or(false));
+        assert!(a2.follows.get("cc").map(|f| f.following).unwrap_or(false));
+    }
+
+    #[test]
+    fn concurrent_follow_unfollow_equal_seq_converges_over_sync() {
+        // Same target, equal seq, follow on A and unfollow on B — the split-brain
+        // case C-1 guards. Over the sync protocol both must settle on unfollow,
+        // in either reconcile direction.
+        let empty = UserShard::default();
+        let a = apply(
+            &empty,
+            vec![ShardDelta::Op(follow_op(&["target"], true, 5))],
+        );
+        let b = apply(
+            &empty,
+            vec![ShardDelta::Op(follow_op(&["target"], false, 5))],
+        );
+
+        let (a2, b2) = reconcile(&a, &b);
+        assert_eq!(canonical(&a2), canonical(&b2));
+        assert!(
+            !a2.follows
+                .get("target")
+                .map(|f| f.following)
+                .unwrap_or(false),
+            "equal-seq unfollow wins after sync"
+        );
+
+        let (b3, a3) = reconcile(&b, &a);
+        assert_eq!(canonical(&a3), canonical(&b3));
+        assert!(
+            !a3.follows
+                .get("target")
+                .map(|f| f.following)
+                .unwrap_or(false)
+        );
+    }
+
+    #[test]
+    fn profile_lww_resolves_over_sync_regardless_of_replica() {
+        // A holds seq 3, B holds seq 1 for the profile register. After sync both
+        // hold seq 3 — the summary folds the profile so a register difference
+        // triggers shipping the newer state.
+        let empty = UserShard::default();
+        let old = Profile {
+            display_name: "Old".into(),
+            handle: "@o".into(),
+            bio: "".into(),
+            avatar: "".into(),
+        };
+        let new = Profile {
+            display_name: "New".into(),
+            handle: "@n".into(),
+            bio: "".into(),
+            avatar: "".into(),
+        };
+        let a = apply(&empty, vec![ShardDelta::Op(profile_op(&new, 3))]);
+        let b = apply(&empty, vec![ShardDelta::Op(profile_op(&old, 1))]);
+
+        let (a2, b2) = reconcile(&a, &b);
+        assert_eq!(canonical(&a2), canonical(&b2));
+        assert_eq!(a2.profile.as_ref().unwrap().seq, 3);
+        assert_eq!(a2.profile.as_ref().unwrap().profile.display_name, "New");
+    }
+
+    #[test]
+    fn non_owner_post_never_propagates_over_sync() {
+        // A malicious replica holds a post signed by a NON-owner key in its state.
+        // When an honest replica syncs from it, update_state re-checks owner
+        // authorship and drops it — owner-writes holds across the sync path.
+        let other = [7u8; 32];
+        let osk = MlDsa65::from_seed(&other.into());
+        let mut foreign = Post {
+            id: String::new(),
+            author_pubkey: hex::encode(osk.verifying_key().encode()),
+            author_name: "Intruder".into(),
+            author_handle: "@intruder".into(),
+            content: "not the owner".into(),
+            timestamp: 50,
+            reply_to: String::new(),
+            signature: None,
+        };
+        foreign.id = foreign.compute_id();
+        let sig: ml_dsa::Signature<MlDsa65> = osk.sign(&foreign.signing_payload());
+        foreign.signature = Some(hex::encode(sig.encode()));
+        // foreign self-verifies as a valid post, just not by the owner.
+        assert_eq!(foreign.verify(), Ok(()));
+
+        let mut malicious = UserShard::default();
+        malicious.posts.push(foreign);
+
+        let honest = UserShard::default();
+        let synced = sync_into(&honest, &malicious);
+        assert!(
+            synced.posts.is_empty(),
+            "non-owner post must not propagate to an honest replica"
+        );
+    }
+}

--- a/docs/adr/0001-implementation-notes.md
+++ b/docs/adr/0001-implementation-notes.md
@@ -281,6 +281,35 @@ instance id — like the user shard). No migration entry (no prior thread-shard
 state). UI wiring + cross-contract quote/notification delivery are Phase 4 / the
 inbox shard (Phase 3).
 
+## Testing tiers
+
+- **Unit** — per-function `#[test]`s inside each contract crate's `test` module:
+  one `validate_state` / `update_state` / merge / truncation rule at a time, with
+  real ML-DSA-65 keys. The convergence and forgery regressions live here.
+- **Integration** — an `integration` module inside the user-shard and thread-shard
+  crates that drives the **full `ContractInterface` through the real sync
+  protocol**: a `sync_into` helper does `dst.summarize_state` →
+  `src.get_state_delta(summary)` → `dst.update_state(delta)` and asserts `dst`
+  stays valid, and `reconcile` runs it both directions and asserts the two
+  replicas reach byte-identical state. This covers what unit tests skip — the
+  summarize/delta wire path and the validate-after-merge invariant — across
+  multi-replica convergence (incl. equal-seq follow/unfollow and like/unlike
+  fixed points in both reconcile orders), adversarial-replica rejection (a forged
+  like / non-owner post in a peer's state must not propagate to an honest
+  replica), and cross-shard key consistency (a user-shard post's content id is the
+  thread-shard param, and a reply bound to it lands only on that thread).
+- **Deferred — WASM-in-node e2e**: these integration tests drive the contract as a
+  Rust library, not the compiled WASM inside a running node, so they do not catch
+  WASM-compilation or transport differences. A real-node tier (via the
+  `freenet:linux-test` / `freenet:local-dev` skills — publish the shards, drive
+  reply/like/quote + two-peer sync over the live WS) is the next testing slice;
+  it is heavier and not a per-PR CI fit. The identity delegate also still lacks
+  unit coverage (deferred from Phase 0).
+
+`cargo make test` now runs `cargo test --workspace` (was a hand-maintained subset
+that omitted the user/thread shards and the delegate) so every crate — and these
+integration tests — run in CI.
+
 ## Caveat: ADR vs. mail on windowing
 
 The ADR states the bounded-state window mirrors "how `freenet/mail` windows its


### PR DESCRIPTION
## What

Adds an **integration** test tier for the ADR-0001 shards: an `integration` module inside the user-shard and thread-shard crates that drives the full `ContractInterface` through the **real sync protocol**, the layer above the existing per-function unit tests.

A `sync_into` helper performs one faithful node sync step —
`dst.summarize_state()` → `src.get_state_delta(summary)` → `dst.update_state(delta)` — and asserts `dst` stays valid; `reconcile` runs it both directions and asserts the two replicas reach **byte-identical** state. This exercises what unit tests skip: the summarize/`get_state_delta` wire path and the validate-after-merge invariant.

## Scenarios (real multi-party ML-DSA-65 keys)

**Thread shard:**
- two-replica convergence across replies + likes + quotes;
- concurrent like/unlike at **equal seq** converges (unlike wins) in **both** reconcile orders;
- higher-seq like propagates over sync;
- a **forged (unsigned) like** in a malicious peer's state does **not** propagate to an honest replica (the CRITICAL fix, now proven over the sync path, not just direct merge);
- **cross-shard**: a user-shard post's content id is the thread param, and a reply bound to it lands only on that thread — not a different one.

**User shard:**
- two-replica convergence across posts + profile + follows;
- concurrent equal-seq follow/unfollow converges (unfollow wins — C-1) both directions;
- profile LWW resolves regardless of replica;
- a **non-owner post** in a malicious peer's state does not propagate to an honest replica (owner-writes holds across sync).

## Also

- Fixes `cargo make test` to run `cargo test --workspace` instead of a hand-maintained subset that **omitted the user/thread shards and the identity delegate** — so all of this (and the prior shard unit tests) actually run in CI.
- Documents the testing tiers in `docs/adr/0001-implementation-notes.md`, including the **deferred WASM-in-node e2e tier** (these drive the contract as a Rust library, not compiled WASM in a running node; real-node coverage via `freenet:linux-test` is the next testing slice).

## Test

user-shard 22 tests (18 unit + 4 integration), thread-shard 21 (16 + 5), full workspace + web (27) green, clippy + fmt clean. No contract source changed → no WASM hash rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)