### PR TITLE
feat: ADR-0001 Phase 4 (slice 1) — UI cutover to user shard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ web/likes_contract_id.txt
 web/delegate_key.txt
 web/delegate_key_bytes.json
 web/delegate_code_hash_bytes.json
+web/user_shard_code_hash.txt
+web/public/user_shard.wasm
 
 # Playwright
 web/tests/node_modules/

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -124,7 +124,21 @@ printf '%s' "$hash" > "$ROOT/build/user_shard_code_hash"
 mkdir -p "$ROOT/web/public"
 cp "$WASM_RAW" "$ROOT/web/public/user_shard.wasm"
 printf '%s' "$hash" > "$ROOT/web/user_shard_code_hash.txt"
-echo "wrote build/user_shard_code_hash + web/public/user_shard.wasm + web/user_shard_code_hash.txt: $hash"
+# Load-bearing safety check: the browser derives each owner's contract key as
+# blake3(code_hash || params) and PUTs the raw wasm, which the node re-hashes to
+# the same code hash. If the shipped wasm's blake3 ever stops equalling the
+# injected (base58) code hash — e.g. fdev packaging drift, or copying the
+# packaged container by mistake — every shard key silently mismatches and all
+# GET/PUT no-op. Fail the build here instead. Compare hex(b3sum raw wasm) to the
+# hex of the base58-decoded code hash (bs58 is in web/node_modules).
+wasm_hex=$(b3sum --no-names "$ROOT/web/public/user_shard.wasm" | tr -d '[:space:]')
+hash_hex=$(cd "$ROOT/web" && node -e "import('bs58').then(m=>process.stdout.write(Buffer.from(m.default.decode(process.argv[1])).toString('hex')))" "$hash")
+if [ "$wasm_hex" != "$hash_hex" ]; then
+    echo "ERROR: shipped user_shard.wasm blake3 ($wasm_hex) != injected code hash ($hash_hex / $hash)" >&2
+    echo "       Did you ship the packaged build/freenet container instead of the raw target wasm?" >&2
+    exit 1
+fi
+echo "wrote build/user_shard_code_hash + web/public/user_shard.wasm + web/user_shard_code_hash.txt: $hash (verified blake3 match)"
 '''
 
 [tasks.build-thread-shard]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -130,9 +130,19 @@ printf '%s' "$hash" > "$ROOT/web/user_shard_code_hash.txt"
 # injected (base58) code hash — e.g. fdev packaging drift, or copying the
 # packaged container by mistake — every shard key silently mismatches and all
 # GET/PUT no-op. Fail the build here instead. Compare hex(b3sum raw wasm) to the
-# hex of the base58-decoded code hash (bs58 is in web/node_modules).
+# hex of the base58-decoded code hash. The base58 decode is done with a
+# self-contained python3 (BITCOIN alphabet) — no npm dep, because contracts
+# build before `npm install` populates web/node_modules in CI.
 wasm_hex=$(b3sum --no-names "$ROOT/web/public/user_shard.wasm" | tr -d '[:space:]')
-hash_hex=$(cd "$ROOT/web" && node -e "import('bs58').then(m=>process.stdout.write(Buffer.from(m.default.decode(process.argv[1])).toString('hex')))" "$hash")
+hash_hex=$(python3 -c '
+import sys
+A = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+n = 0
+for c in sys.argv[1]:
+    n = n * 58 + A.index(c)
+b = n.to_bytes(32, "big")
+sys.stdout.write(b.hex())
+' "$hash")
 if [ "$wasm_hex" != "$hash_hex" ]; then
     echo "ERROR: shipped user_shard.wasm blake3 ($wasm_hex) != injected code hash ($hash_hex / $hash)" >&2
     echo "       Did you ship the packaged build/freenet container instead of the raw target wasm?" >&2

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -99,8 +99,15 @@ set -euo pipefail
 ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
 cd "$ROOT/contracts/user-shard"
 CARGO_TARGET_DIR="$ROOT/target" fdev build
+# Two artifacts exist: the packaged container at build/freenet/… (what `fdev
+# inspect` reads, with extra framing) and the raw compiled .wasm under target/.
+# The node's code hash is blake3 of the RAW wasm, and on PUT the node re-hashes
+# the `data` bytes we send to derive the key — so the browser must ship the RAW
+# wasm, not the packaged container, or the derived instance id won't match.
+WASM_PKG="$ROOT/contracts/user-shard/build/freenet/freenet_microblogging_user_shard"
+WASM_RAW="$ROOT/target/wasm32-unknown-unknown/release/freenet_microblogging_user_shard.wasm"
 hash=$(CARGO_TARGET_DIR="$ROOT/target" fdev inspect \
-    "$ROOT/contracts/user-shard/build/freenet/freenet_microblogging_user_shard" code | \
+    "$WASM_PKG" code | \
     grep 'code hash:' | cut -d' ' -f3)
 mkdir -p "$ROOT/build"
 # User shards are PARAMETERIZED (parameters = owner ML-DSA-65 VK), so there is
@@ -108,7 +115,16 @@ mkdir -p "$ROOT/build"
 # code_hash + their VK. Only the code_hash is build-stable; instance ids are
 # computed per owner at runtime (ADR-0001 → "Shard key derivation").
 printf '%s' "$hash" > "$ROOT/build/user_shard_code_hash"
-echo "wrote build/user_shard_code_hash: $hash"
+# The web UI PUTs the parameterized container itself (code + owner VK params)
+# to instantiate each user's shard, so it needs the contract WASM bytes at
+# runtime. Mirror the built artifact + code hash into web/ for bundling:
+# vite serves web/public/* verbatim at the dist root, so the app fetches
+# ./user_shard.wasm at runtime; __USER_SHARD_CODE_HASH__ is injected from
+# user_shard_code_hash.txt.
+mkdir -p "$ROOT/web/public"
+cp "$WASM_RAW" "$ROOT/web/public/user_shard.wasm"
+printf '%s' "$hash" > "$ROOT/web/user_shard_code_hash.txt"
+echo "wrote build/user_shard_code_hash + web/public/user_shard.wasm + web/user_shard_code_hash.txt: $hash"
 '''
 
 [tasks.build-thread-shard]

--- a/docs/adr/0001-implementation-notes.md
+++ b/docs/adr/0001-implementation-notes.md
@@ -393,6 +393,68 @@ instance id — like the user and thread shards). No migration entry (no prior
 inbox-shard state). With this slice **all three shard types now exist**, so the
 migration + UI wiring (Phase 4) is unblocked.
 
+## Phase 4 decisions (UI cutover — user shard, slice 1)
+
+Phase 4 cuts the web app from the legacy global posts contract to the per-user
+shards. It is sliced: this first slice wires only the **user shard**
+(posts/profile/follows surface) for read + write; thread/inbox UI and migration
+of legacy global-feed data into shards are later slices.
+
+### Client-side key derivation must match the node byte-for-byte
+
+A parameterized shard's contract instance id is
+`blake3(code_hash_bytes || parameters_bytes)` — the raw 32-byte code hash
+concatenated with the raw parameter blob, **no length prefix, no separator, no
+domain tag**, taking the 32-byte digest (freenet-stdlib
+`ContractKey::generate_id` / `from_params`). The web app reproduces this in
+`web/src/shard-key.ts` with `@noble/hashes/blake3` + `bs58`. If the JS derivation
+drifts from the node, every GET/PUT/subscribe silently addresses a different
+(empty) contract, so the match is pinned by a **ground-truth vector** in
+`shard-key.test.ts` taken from `fdev get-contract-id --code … --parameters …`
+(code hash `7iSNUfGW…`, 32×`0x01` params → instance id `2q69AnoP…`). The vector
+depends only on the algorithm (code hash + params), so it survives rebuilds.
+
+The shard parameters are the **raw owner ML-DSA-65 VK bytes** (1952 B), matching
+the contract's `owner_vk_hex(params) = hex(params)`. (Note: freenet-email
+JSON-encodes its inbox params; raven does not — the contract dictates the wire
+form, and raven's expects raw VK bytes.)
+
+### The browser PUTs the parameterized container itself
+
+The node has no pre-published per-owner instance, so the app instantiates each
+owner's shard by PUTting a `ContractContainer` (raw WASM `data` + owner-VK
+`parameters` + derived key) with an empty initial state `{"posts":[]}`, then
+GET/subscribes by the derived key. `setUser` (fired when the delegate reports the
+identity) is the trigger; `initUserShard` derives the key, GETs to check for an
+existing instance, PUTs to instantiate if absent, then loads + subscribes. A real
+VK is 3904 hex chars — the 64-char offline fake is not treated as a shard owner.
+
+**The shipped WASM must be the raw compiled artifact, not the packaged
+container.** `fdev`'s code hash is `blake3` of the raw `target/…/*.wasm`; the
+packaged `build/freenet/…` file has extra framing and hashes differently. On PUT
+the node re-hashes the `data` bytes to derive the key, so shipping the packaged
+file would derive a key that never matches the GET key. `Makefile.toml`
+`build-user-shard` copies the **raw** wasm to `web/public/user_shard.wasm` and
+injects its base58 code hash as `__USER_SHARD_CODE_HASH__`; a build-time check is
+that `b3sum web/public/user_shard.wasm` equals the injected code hash.
+
+### Delta form differs from the legacy feed
+
+The user shard takes the externally-tagged `ShardDelta` enum, so a post is
+written as `{"Posts":[post]}` (vs. the legacy global feed's bare `[post]` array),
+and an incoming shard delta is parsed by the `Posts` tag (an `Op` delta carries
+profile/follow changes, no feed posts). State reads route by the response key:
+the shard returns a `UserShard` (`{posts,profile,follows}`), the legacy feed a
+`{posts}`. Until a real VK is known the app stays on the legacy contract, so the
+slice is additive and reversible.
+
+### Not exercised by per-PR CI
+
+The PUT-container / GET-by-derived-key round-trip is only exercised against a live
+node (deferred WASM-in-node tier), not vitest. The load-bearing invariant that
+*is* unit-tested is the key derivation match — the one thing that, if wrong,
+makes everything silently no-op.
+
 ## Testing tiers
 
 - **Unit** — per-function `#[test]`s inside each contract crate's `test` module:

--- a/docs/adr/0001-implementation-notes.md
+++ b/docs/adr/0001-implementation-notes.md
@@ -435,8 +435,10 @@ packaged `build/freenet/…` file has extra framing and hashes differently. On P
 the node re-hashes the `data` bytes to derive the key, so shipping the packaged
 file would derive a key that never matches the GET key. `Makefile.toml`
 `build-user-shard` copies the **raw** wasm to `web/public/user_shard.wasm` and
-injects its base58 code hash as `__USER_SHARD_CODE_HASH__`; a build-time check is
-that `b3sum web/public/user_shard.wasm` equals the injected code hash.
+injects its base58 code hash as `__USER_SHARD_CODE_HASH__`. The task then fails
+the build unless `b3sum web/public/user_shard.wasm` (hex) equals the
+base58-decoded injected code hash (hex) — the one assertion that catches a
+raw-vs-packaged mix-up, which would otherwise be a silent network-wide no-op.
 
 ### Delta form differs from the legacy feed
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5,7 +5,9 @@
   "packages": {
     "": {
       "dependencies": {
-        "@freenetorg/freenet-stdlib": "^0.2.0"
+        "@freenetorg/freenet-stdlib": "^0.2.0",
+        "@noble/hashes": "^1.8.0",
+        "bs58": "^6.0.0"
       },
       "devDependencies": {
         "sass": "^1.87.0",
@@ -521,6 +523,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@parcel/watcher": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@freenetorg/freenet-stdlib": "^0.2.0"
+    "@freenetorg/freenet-stdlib": "^0.2.0",
+    "@noble/hashes": "^1.8.0",
+    "bs58": "^6.0.0"
   },
   "devDependencies": {
     "sass": "^1.87.0",

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -144,8 +144,20 @@ export class FreenetConnection {
   private userShardKey: ContractKey | null = null;
   /** Base58 instance id of {@link userShardKey}, for response key matching. */
   private userShardInstanceId: string | null = null;
-  /** Guards against re-running user-shard init for the same owner. */
-  private userShardInit = false;
+  /** Guards against concurrent user-shard init for the SAME owner. Reset when
+   * the owner VK changes (identity switch) so the new shard re-initialises. */
+  private userShardInitOwner: string | null = null;
+  /**
+   * Resolves once {@link startup} (migration loop + legacy load/subscribe) has
+   * finished. The stdlib resolves GET responses from a single FIFO queue with
+   * no request correlation, so issuing the shard's probe/load GETs while the
+   * migration loop is still awaiting its own GETs lets the two steal each
+   * other's responses (a shard NotFound could reject a migration GET, and a
+   * legacy response could resolve the shard probe → a spurious "exists" → the
+   * shard is never PUT). Serialise shard init behind this barrier.
+   */
+  private startupDone: Promise<void> = Promise.resolve();
+  private resolveStartupDone: () => void = () => {};
 
   constructor(callbacks: FreenetCallbacks) {
     this.callbacks = callbacks;
@@ -221,9 +233,17 @@ export class FreenetConnection {
 
   /** Run the migration loop, then load + subscribe to the current contract. */
   private async startup(): Promise<void> {
-    await this.runStartupMigrations();
-    this.loadState();
-    this.subscribeToUpdates();
+    this.startupDone = new Promise((resolve) => {
+      this.resolveStartupDone = resolve;
+    });
+    try {
+      await this.runStartupMigrations();
+      this.loadState();
+      this.subscribeToUpdates();
+    } finally {
+      // Unblock any user-shard init that arrived (via setUser) mid-startup.
+      this.resolveStartupDone();
+    }
   }
 
   /**
@@ -320,8 +340,12 @@ export class FreenetConnection {
   }
 
   loadState(): void {
-    if (!this.api || !this.contractKey) return;
-    const req = new GetRequest(this.contractKey, true);
+    // Once the user shard is active it is the sole feed source; otherwise read
+    // the legacy global contract. (index.ts refreshes via loadState after a
+    // publish, so this must follow the same target writes go to.)
+    const target = this.userShardKey ?? this.contractKey;
+    if (!this.api || !target) return;
+    const req = new GetRequest(target, true);
     this.api.get(req).catch((e) =>
       console.error("[freenet] Get request failed:", e)
     );
@@ -351,15 +375,18 @@ export class FreenetConnection {
     // state never lands in the live feed.
     if (this.migrating) return;
     try {
+      const respId = this.responseInstanceId(response.key);
+      const isShard =
+        this.userShardInstanceId !== null &&
+        respId === this.userShardInstanceId;
+      // Once the shard is active it is the sole feed source — drop any straggler
+      // legacy-contract GET response so the two feeds never mix.
+      if (this.usingUserShard && !isShard) return;
       const decoder = new TextDecoder("utf8");
       const stateJson = decoder.decode(Uint8Array.from(response.state));
       // Route by the response's key: user-shard state is a `UserShard`
       // (`{posts, profile, follows}`); the legacy global feed is a
       // `PostsFeedState` (`{posts}`).
-      const respId = this.responseInstanceId(response.key);
-      const isShard =
-        this.userShardInstanceId !== null &&
-        respId === this.userShardInstanceId;
       const rawPosts = isShard
         ? (JSON.parse(stateJson) as UserShardState).posts ?? []
         : (JSON.parse(stateJson) as PostsFeedState).posts;
@@ -374,6 +401,14 @@ export class FreenetConnection {
 
   private handleUpdateNotification(notification: UpdateNotification): void {
     try {
+      // Once the shard is active, only its update notifications drive the feed;
+      // ignore notifications from the still-subscribed legacy contract (the
+      // stdlib has no unsubscribe), so writes-to-shard / reads-from-shard stay
+      // consistent.
+      if (this.usingUserShard) {
+        const notifId = this.responseInstanceId(notification.key);
+        if (notifId !== this.userShardInstanceId) return;
+      }
       const updateData = notification.update as UpdateData;
       if (!updateData || updateData.updateDataType !== UpdateDataType.DeltaUpdate) return;
       const delta = updateData.updateData as { delta: number[] } | null;
@@ -413,7 +448,10 @@ export class FreenetConnection {
    * load + subscribe so the feed reflects the owner's shard. ADR-0001 Phase 4.
    */
   private async initUserShard(): Promise<void> {
-    if (!this.api || !this.ownerVkHex || this.userShardInit) return;
+    const owner = this.ownerVkHex;
+    // Re-entry guard keyed by owner: a duplicate Identity for the same owner is
+    // a no-op, but a new owner (identity switch) must re-initialise.
+    if (!this.api || !owner || this.userShardInitOwner === owner) return;
     const codeHash =
       typeof __USER_SHARD_CODE_HASH__ !== "undefined"
         ? __USER_SHARD_CODE_HASH__
@@ -422,13 +460,21 @@ export class FreenetConnection {
       console.warn("[user-shard] No code hash injected — staying on legacy feed");
       return;
     }
-    this.userShardInit = true;
+    this.userShardInitOwner = owner;
     try {
-      const vkBytes = hexToBytes(this.ownerVkHex);
+      // Wait until the startup migration loop + legacy load/subscribe have
+      // finished before issuing any shard GET. The stdlib's GET response queue
+      // is an uncorrelated FIFO; overlapping the two flows lets them steal each
+      // other's responses (see startupDone).
+      await this.startupDone;
+      // A newer identity may have arrived while we awaited — bail if so.
+      if (this.ownerVkHex !== owner) return;
+
+      const vkBytes = hexToBytes(owner);
       this.userShardKey = deriveShardContractKey(codeHash, vkBytes);
       this.userShardInstanceId = this.userShardKey.encode();
       console.log(
-        `[user-shard] derived key ${this.userShardInstanceId} for owner ${this.ownerVkHex.slice(0, 8)}…`,
+        `[user-shard] derived key ${this.userShardInstanceId} for owner ${owner.slice(0, 8)}…`,
       );
 
       // Probe for an existing instance. A brand-new owner has none, so PUT the
@@ -446,10 +492,19 @@ export class FreenetConnection {
       // Fall back to the legacy feed already wired via this.contractKey.
       this.userShardKey = null;
       this.userShardInstanceId = null;
+      this.userShardInitOwner = null;
     }
   }
 
-  /** GET the user shard to check whether the node already has this instance. */
+  /**
+   * GET the user shard to check whether the node already has this instance.
+   * A genuine not-found AND a transient timeout both return false → we PUT. A
+   * spurious PUT over an already-existing shard is safe: Freenet PUT-of-existing
+   * runs the contract's CRDT merge (`update_state` → `merge_state`), not an
+   * overwrite, so PUTting the empty `{"posts":[]}` initial state merges to a
+   * no-op (posts union / profile LWW / follows set-union). The only cost is
+   * re-sending the WASM on a slow GET.
+   */
   private async userShardExists(): Promise<boolean> {
     if (!this.api || !this.userShardKey) return false;
     try {
@@ -459,7 +514,6 @@ export class FreenetConnection {
       );
       return true;
     } catch {
-      // A not-found / timeout means we should PUT to instantiate.
       return false;
     }
   }

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -175,6 +175,14 @@ export class FreenetConnection {
 
     this.callbacks.onStatusChange("connecting");
 
+    // Arm the startup barrier synchronously, before the socket opens — a
+    // delegate identity (→ setUser → initUserShard) can never beat startup() to
+    // assigning it, so shard init always awaits the real barrier, not the
+    // default-resolved field.
+    this.startupDone = new Promise((resolve) => {
+      this.resolveStartupDone = resolve;
+    });
+
     try {
       // Build ContractKey with both instance and code parts.
       // fromInstanceId only sets instance — we need both for the node.
@@ -233,9 +241,8 @@ export class FreenetConnection {
 
   /** Run the migration loop, then load + subscribe to the current contract. */
   private async startup(): Promise<void> {
-    this.startupDone = new Promise((resolve) => {
-      this.resolveStartupDone = resolve;
-    });
+    // The barrier promise is armed synchronously in connect() so a delegate
+    // identity cannot beat us to it; here we only resolve it once done.
     try {
       await this.runStartupMigrations();
       this.loadState();

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -1,8 +1,12 @@
 import {
   FreenetWsApi,
   ContractKey,
+  ContractContainer,
+  ContractType as WasmContractType,
+  WasmContractV1,
   GetRequest,
   GetResponse,
+  PutRequest,
   UpdateRequest,
   UpdateResponse,
   UpdateNotification,
@@ -15,7 +19,11 @@ import {
   HostError,
   ResponseHandler,
 } from "@freenetorg/freenet-stdlib";
+// ContractCodeT is the constructable flatbuffer code table (with .pack()). It
+// is not re-exported from the package root, only the /common subpath.
+import { ContractCodeT } from "@freenetorg/freenet-stdlib/common";
 import { Post } from "./types";
+import { deriveShardContractKey, hexToBytes } from "./shard-key";
 import { signPost } from "./identity";
 import { runMigrations, type MigrationRunnerDeps } from "./migrations/run";
 import {
@@ -52,6 +60,14 @@ interface PendingPostDraft {
 
 interface PostsFeedState {
   posts: ContractPost[];
+}
+
+// User-shard state (matches Rust `UserShard`). Only `posts` is consumed by the
+// feed today; profile/follows are deserialized-tolerant (present-or-absent).
+interface UserShardState {
+  posts?: ContractPost[];
+  profile?: unknown;
+  follows?: Record<string, unknown>;
 }
 
 // Convert contract format → UI format
@@ -115,6 +131,21 @@ export class FreenetConnection {
   private migrating = false;
   /** Drafts awaiting a delegate `Signed` response, FIFO. See publishPost. */
   private pendingPosts: PendingPostDraft[] = [];
+  /**
+   * The owner's ML-DSA-65 verifying key (hex) once the delegate reports the
+   * identity. Used to derive this owner's user-shard key. Null until known.
+   */
+  private ownerVkHex: string | null = null;
+  /**
+   * The per-owner user-shard contract key, derived from the owner VK and the
+   * build-injected shard code hash (ADR-0001 Phase 4). Once set, the feed reads
+   * and writes the user shard instead of the legacy global posts contract.
+   */
+  private userShardKey: ContractKey | null = null;
+  /** Base58 instance id of {@link userShardKey}, for response key matching. */
+  private userShardInstanceId: string | null = null;
+  /** Guards against re-running user-shard init for the same owner. */
+  private userShardInit = false;
 
   constructor(callbacks: FreenetCallbacks) {
     this.callbacks = callbacks;
@@ -304,6 +335,15 @@ export class FreenetConnection {
     );
   }
 
+  /** Base58 instance id of a response's key, for matching against our keys. */
+  private responseInstanceId(key: ContractKey | null | undefined): string | null {
+    try {
+      return key ? key.encode() : null;
+    } catch {
+      return null;
+    }
+  }
+
   private handleGetResponse(response: GetResponse): void {
     // The startup migration loop issues GETs against old contract keys and
     // consumes those responses via the awaited Promise returned by api.get().
@@ -313,8 +353,17 @@ export class FreenetConnection {
     try {
       const decoder = new TextDecoder("utf8");
       const stateJson = decoder.decode(Uint8Array.from(response.state));
-      const state: PostsFeedState = JSON.parse(stateJson);
-      const posts = state.posts.map(contractPostToUiPost);
+      // Route by the response's key: user-shard state is a `UserShard`
+      // (`{posts, profile, follows}`); the legacy global feed is a
+      // `PostsFeedState` (`{posts}`).
+      const respId = this.responseInstanceId(response.key);
+      const isShard =
+        this.userShardInstanceId !== null &&
+        respId === this.userShardInstanceId;
+      const rawPosts = isShard
+        ? (JSON.parse(stateJson) as UserShardState).posts ?? []
+        : (JSON.parse(stateJson) as PostsFeedState).posts;
+      const posts = rawPosts.map(contractPostToUiPost);
       // Sort by timestamp descending (newest first)
       posts.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
       this.callbacks.onPostsLoaded(posts);
@@ -331,9 +380,15 @@ export class FreenetConnection {
       if (!delta) return;
       const decoder = new TextDecoder("utf8");
       const deltaJson = decoder.decode(Uint8Array.from(delta.delta));
-      const newPosts: ContractPost[] = JSON.parse(
-        deltaJson.replace("\x00", "")
-      );
+      const parsed = JSON.parse(deltaJson.replace("\x00", "")) as
+        | ContractPost[]
+        | { Posts?: ContractPost[]; Op?: unknown };
+      // User-shard deltas are the externally-tagged `ShardDelta` enum
+      // (`{"Posts":[…]}` / `{"Op":…}`); the legacy feed sends a bare post array.
+      // Op deltas (profile/follow) carry no feed posts — ignore them here.
+      const newPosts: ContractPost[] = Array.isArray(parsed)
+        ? parsed
+        : parsed.Posts ?? [];
       for (const cp of newPosts) {
         this.callbacks.onNewPost(contractPostToUiPost(cp));
       }
@@ -344,6 +399,140 @@ export class FreenetConnection {
 
   setUser(pubkey: string, name: string, handle: string): void {
     this.currentUser = { pubkey, name, handle };
+    // A real ML-DSA-65 VK is 1952 bytes → 3904 hex chars. The offline fallback
+    // identity uses a 32-byte fake (64 hex chars), which is not a shard owner.
+    if (pubkey && pubkey.length === 3904 && pubkey !== this.ownerVkHex) {
+      this.ownerVkHex = pubkey;
+      void this.initUserShard();
+    }
+  }
+
+  /**
+   * Derive this owner's user-shard key, ensure the contract is instantiated on
+   * the node (PUT the parameterized container if it is not yet present), then
+   * load + subscribe so the feed reflects the owner's shard. ADR-0001 Phase 4.
+   */
+  private async initUserShard(): Promise<void> {
+    if (!this.api || !this.ownerVkHex || this.userShardInit) return;
+    const codeHash =
+      typeof __USER_SHARD_CODE_HASH__ !== "undefined"
+        ? __USER_SHARD_CODE_HASH__
+        : null;
+    if (!codeHash || codeHash === "DEV_MODE_NO_CONTRACT_HASH") {
+      console.warn("[user-shard] No code hash injected — staying on legacy feed");
+      return;
+    }
+    this.userShardInit = true;
+    try {
+      const vkBytes = hexToBytes(this.ownerVkHex);
+      this.userShardKey = deriveShardContractKey(codeHash, vkBytes);
+      this.userShardInstanceId = this.userShardKey.encode();
+      console.log(
+        `[user-shard] derived key ${this.userShardInstanceId} for owner ${this.ownerVkHex.slice(0, 8)}…`,
+      );
+
+      // Probe for an existing instance. A brand-new owner has none, so PUT the
+      // parameterized container (raw WASM + owner VK params + empty initial
+      // state) to instantiate it before subscribing.
+      const exists = await this.userShardExists();
+      if (!exists) {
+        await this.putUserShard(vkBytes, codeHash);
+      }
+
+      this.loadUserShard();
+      this.subscribeUserShard();
+    } catch (e) {
+      console.error("[user-shard] init failed:", e);
+      // Fall back to the legacy feed already wired via this.contractKey.
+      this.userShardKey = null;
+      this.userShardInstanceId = null;
+    }
+  }
+
+  /** GET the user shard to check whether the node already has this instance. */
+  private async userShardExists(): Promise<boolean> {
+    if (!this.api || !this.userShardKey) return false;
+    try {
+      await this.withTimeout(
+        this.api.get(new GetRequest(this.userShardKey, false)),
+        8000,
+      );
+      return true;
+    } catch {
+      // A not-found / timeout means we should PUT to instantiate.
+      return false;
+    }
+  }
+
+  /** Fetch the bundled raw shard WASM bytes (served at the dist root). */
+  private async fetchShardWasm(): Promise<Uint8Array> {
+    const resp = await fetch("./user_shard.wasm");
+    if (!resp.ok) {
+      throw new Error(`failed to fetch user_shard.wasm: ${resp.status}`);
+    }
+    return new Uint8Array(await resp.arrayBuffer());
+  }
+
+  /**
+   * PUT the parameterized user-shard container to instantiate this owner's
+   * shard. The node re-hashes the `data` bytes to derive the key, so the
+   * shipped WASM must be the raw compiled artifact whose blake3 equals the
+   * injected code hash (see Makefile.toml build-user-shard).
+   */
+  private async putUserShard(
+    vkBytes: Uint8Array,
+    codeHashBase58: string,
+  ): Promise<void> {
+    if (!this.api || !this.userShardKey) return;
+    const wasm = await this.fetchShardWasm();
+    const codeHashBytes = this.userShardKey.codePart();
+    const code = new ContractCodeT(
+      Array.from(wasm),
+      codeHashBytes ? Array.from(codeHashBytes) : [],
+    );
+    const contract = new WasmContractV1(
+      code,
+      Array.from(vkBytes),
+      this.userShardKey,
+    );
+    const container = new ContractContainer(
+      WasmContractType.WasmContractV1,
+      contract,
+    );
+    // Empty initial state; `UserShard` defaults fill the rest (posts: []).
+    const initialState = new TextEncoder().encode(
+      JSON.stringify({ posts: [] }),
+    );
+    const req = new PutRequest(
+      container,
+      Array.from(initialState),
+      undefined,
+      false,
+      false,
+    );
+    console.log(
+      `[user-shard] PUT instantiating shard (${codeHashBase58.slice(0, 8)}…)`,
+    );
+    await this.api.put(req);
+  }
+
+  private loadUserShard(): void {
+    if (!this.api || !this.userShardKey) return;
+    this.api
+      .get(new GetRequest(this.userShardKey, true))
+      .catch((e) => console.error("[user-shard] get failed:", e));
+  }
+
+  private subscribeUserShard(): void {
+    if (!this.api || !this.userShardKey) return;
+    this.api
+      .subscribe(new SubscribeRequest(this.userShardKey, []))
+      .catch((e) => console.error("[user-shard] subscribe failed:", e));
+  }
+
+  /** True once the feed is sourced from the owner's user shard. */
+  private get usingUserShard(): boolean {
+    return this.userShardKey !== null;
   }
 
   /**
@@ -355,7 +544,10 @@ export class FreenetConnection {
    * per-request, so we hold the draft until the signature returns.)
    */
   async publishPost(content: string): Promise<boolean> {
-    if (!this.api || !this.contractKey || !this.currentUser) {
+    // A target key is either the user shard (preferred once known) or the
+    // legacy global contract.
+    const target = this.userShardKey ?? this.contractKey;
+    if (!this.api || !target || !this.currentUser) {
       return false;
     }
     const timestamp = Date.now();
@@ -399,7 +591,8 @@ export class FreenetConnection {
     signature: string;
     public_key: string;
   }): Promise<boolean> {
-    if (!this.api || !this.contractKey) return false;
+    const target = this.userShardKey ?? this.contractKey;
+    if (!this.api || !target) return false;
 
     // Match the draft by its unique nonce, not position or timestamp — robust
     // to a dropped/errored sign request and to same-millisecond posts.
@@ -425,10 +618,13 @@ export class FreenetConnection {
 
     try {
       const encoder = new TextEncoder();
-      const deltaBytes = encoder.encode(JSON.stringify([post]));
+      // The user shard expects the externally-tagged `ShardDelta::Posts` form;
+      // the legacy global contract takes a bare post array.
+      const payload = this.usingUserShard ? { Posts: [post] } : [post];
+      const deltaBytes = encoder.encode(JSON.stringify(payload));
       const delta = new DeltaUpdate(Array.from(deltaBytes));
       const update = new UpdateData(UpdateDataType.DeltaUpdate, delta);
-      const req = new UpdateRequest(this.contractKey, update);
+      const req = new UpdateRequest(target, update);
       await this.api.update(req);
       return true;
     } catch (e) {

--- a/web/src/shard-key.test.ts
+++ b/web/src/shard-key.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveInstanceId,
+  deriveShardContractKey,
+  hexToBytes,
+} from "./shard-key";
+
+describe("shard-key derivation", () => {
+  // GROUND TRUTH pinned from the real node code path:
+  //   $ fdev get-contract-id \
+  //       --code target/wasm32-unknown-unknown/release/freenet_microblogging_user_shard.wasm \
+  //       --parameters <32 bytes of 0x01>
+  //   => 2q69AnoP5Eb61W8WesCH9NkiKnr6cDhyMhKdPgzCtxvo
+  // with code hash 7iSNUfGW4WiJMuQ3ryxsD7KNPDAi31MpNoQ2nhPJRDXm.
+  //
+  // This vector is independent of the WASM bytes (depends only on the code
+  // hash + params), so it stays valid across rebuilds as long as the node's
+  // derivation algorithm — blake3(code_hash || params) — is unchanged. If this
+  // test ever fails, the JS derivation has drifted from the node and every
+  // GET/PUT against a shard would silently address the wrong (empty) contract.
+  const CODE_HASH = "7iSNUfGW4WiJMuQ3ryxsD7KNPDAi31MpNoQ2nhPJRDXm";
+
+  it("matches the node-derived instance id (fixed 32-byte params)", () => {
+    const params = new Uint8Array(32).fill(1);
+    expect(deriveInstanceId(CODE_HASH, params).base58).toBe(
+      "2q69AnoP5Eb61W8WesCH9NkiKnr6cDhyMhKdPgzCtxvo",
+    );
+  });
+
+  it("is deterministic for the same inputs", () => {
+    const params = new Uint8Array(32).fill(7);
+    const a = deriveInstanceId(CODE_HASH, params).base58;
+    const b = deriveInstanceId(CODE_HASH, params).base58;
+    expect(a).toBe(b);
+  });
+
+  it("differs when params differ (per-owner keys are distinct)", () => {
+    const a = deriveInstanceId(CODE_HASH, new Uint8Array(32).fill(1)).base58;
+    const b = deriveInstanceId(CODE_HASH, new Uint8Array(32).fill(2)).base58;
+    expect(a).not.toBe(b);
+  });
+
+  it("ContractKey instance id encodes to the derived instance id", () => {
+    // The key the app GET/PUT/subscribes with must address the same instance id
+    // we derive — otherwise responses never match. Pin that they agree.
+    const params = new Uint8Array(32).fill(1);
+    const key = deriveShardContractKey(CODE_HASH, params);
+    expect(key.encode()).toBe(deriveInstanceId(CODE_HASH, params).base58);
+    expect(key.encode()).toBe("2q69AnoP5Eb61W8WesCH9NkiKnr6cDhyMhKdPgzCtxvo");
+  });
+
+  it("ContractKey carries the code hash bytes separately from the instance", () => {
+    const key = deriveShardContractKey(CODE_HASH, new Uint8Array(32).fill(1));
+    const codePart = key.codePart();
+    expect(codePart).not.toBeNull();
+    expect(codePart!.length).toBe(32);
+  });
+
+  it("rejects a code hash that does not decode to 32 bytes", () => {
+    expect(() => deriveInstanceId("abc", new Uint8Array(0))).toThrow(
+      /32 bytes/,
+    );
+  });
+
+  describe("hexToBytes", () => {
+    it("round-trips a known hex string", () => {
+      const b = hexToBytes("0a0b0c");
+      expect(Array.from(b)).toEqual([10, 11, 12]);
+    });
+
+    it("decodes a full ML-DSA-65 VK length (1952 bytes from 3904 hex chars)", () => {
+      const hex = "ab".repeat(1952);
+      expect(hexToBytes(hex).length).toBe(1952);
+    });
+
+    it("rejects odd-length hex", () => {
+      expect(() => hexToBytes("abc")).toThrow(/odd length/);
+    });
+
+    it("rejects invalid hex digits", () => {
+      expect(() => hexToBytes("zz")).toThrow(/invalid hex/);
+    });
+  });
+});

--- a/web/src/shard-key.ts
+++ b/web/src/shard-key.ts
@@ -1,0 +1,83 @@
+import { blake3 } from "@noble/hashes/blake3";
+import bs58 from "bs58";
+import { ContractKey } from "@freenetorg/freenet-stdlib";
+
+// Derive a parameterized contract's instance id exactly as the Freenet node
+// does. The node computes (freenet-stdlib `ContractKey::generate_id` /
+// `from_params`):
+//
+//   instance_id = blake3( code_hash_bytes || parameters_bytes )
+//
+// where code_hash_bytes is the raw 32 bytes the contract's base58 code hash
+// decodes to, and parameters_bytes is the raw parameter blob with NO length
+// prefix, NO domain separation, and NO separator. The 32-byte digest is the
+// instance id, base58-encoded for string form.
+//
+// This MUST match the node byte-for-byte or GET/PUT/UPDATE address a different
+// (empty) contract and silently no-op. The match is pinned by a ground-truth
+// vector in shard-key.test.ts derived from `fdev get-contract-id`.
+
+/** Raw 32 bytes a base58 contract code hash decodes to. */
+function decodeCodeHash(codeHashBase58: string): Uint8Array {
+  const bytes = bs58.decode(codeHashBase58);
+  if (bytes.length !== 32) {
+    throw new Error(
+      `code hash must decode to 32 bytes, got ${bytes.length}: ${codeHashBase58}`,
+    );
+  }
+  return bytes;
+}
+
+/** Decode a hex string (e.g. an ML-DSA-65 verifying key) to raw bytes. */
+export function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error(`hex string has odd length: ${hex.length}`);
+  }
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) throw new Error(`invalid hex at offset ${i * 2}`);
+    out[i] = byte;
+  }
+  return out;
+}
+
+/**
+ * Compute the contract instance id for a parameterized contract.
+ * @param codeHashBase58 the build-stable code hash (base58, 32 bytes decoded)
+ * @param parameters the raw parameter bytes (for shards: the owner VK bytes)
+ * @returns the 32-byte instance id and its base58 string form
+ */
+export function deriveInstanceId(
+  codeHashBase58: string,
+  parameters: Uint8Array,
+): { bytes: Uint8Array; base58: string } {
+  const codeBytes = decodeCodeHash(codeHashBase58);
+  const concat = new Uint8Array(codeBytes.length + parameters.length);
+  concat.set(codeBytes, 0);
+  concat.set(parameters, codeBytes.length);
+  const id = blake3(concat); // 32-byte digest
+  return { bytes: id, base58: bs58.encode(id) };
+}
+
+/**
+ * Build the node ContractKey for a parameterized contract instance. The key
+ * carries the derived instance id and the contract code hash separately (unlike
+ * the no-parameter shortcut in freenet-api.ts where both are the same bytes).
+ */
+export function deriveShardContractKey(
+  codeHashBase58: string,
+  parameters: Uint8Array,
+): ContractKey {
+  const instance = deriveInstanceId(codeHashBase58, parameters);
+  const codeBytes = decodeCodeHash(codeHashBase58);
+  // The runtime ContractKey constructor takes two 32-byte arrays (instance id,
+  // code hash) — it wraps the first in a ContractInstanceIdT itself. The
+  // published .d.ts types the first arg as ContractInstanceId, so cast the raw
+  // 32-byte arrays through unknown. This mirrors freenet-api.ts deriveContractKey
+  // (`new ContractKey(bytes, bytes)`), which passes Uint8Array(32) the same way.
+  return new ContractKey(
+    instance.bytes as unknown as ConstructorParameters<typeof ContractKey>[0],
+    codeBytes,
+  );
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 declare const __MODEL_CONTRACT__: string;
+declare const __USER_SHARD_CODE_HASH__: string;
 declare const __FOLLOWS_CONTRACT__: string;
 declare const __LIKES_CONTRACT__: string;
 declare const __DELEGATE_KEY__: string;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,6 +11,7 @@ function readFileOrDefault(filename: string, fallback: string): string {
 export default defineConfig({
   define: {
     __MODEL_CONTRACT__: JSON.stringify(readFileOrDefault("model_code_hash.txt", "DEV_MODE_NO_CONTRACT_HASH")),
+    __USER_SHARD_CODE_HASH__: JSON.stringify(readFileOrDefault("user_shard_code_hash.txt", "DEV_MODE_NO_CONTRACT_HASH")),
     __FOLLOWS_CONTRACT__: JSON.stringify(readFileOrDefault("follows_contract_id.txt", "DEV_MODE_NO_CONTRACT_HASH")),
     __LIKES_CONTRACT__: JSON.stringify(readFileOrDefault("likes_contract_id.txt", "DEV_MODE_NO_CONTRACT_HASH")),
     __DELEGATE_KEY__: JSON.stringify(readFileOrDefault("delegate_key.txt", "")),


### PR DESCRIPTION
## What

First slice of ADR-0001 **Phase 4** (global-contract → shard cutover). Wires the web app to read + write the per-user **user shard** (posts/profile/follows surface). Thread/inbox UI and migration of legacy global-feed data into shards are later slices.

## How

- **Key derivation** (`web/src/shard-key.ts`): instance id = `blake3(code_hash_bytes || params_bytes)` — raw concat, no length prefix/domain tag, 32-byte digest, base58 — via `@noble/hashes` + `bs58`. Params = raw owner ML-DSA-65 VK bytes (matches contract `owner_vk_hex = hex(params)`).
- **Instantiation** (`freenet-api.ts`): on `setUser` (delegate identity), derive key → GET probe → PUT parameterized `ContractContainer` (raw WASM + VK params + empty state) if absent → GET/subscribe. Posts write as `ShardDelta` `{"Posts":[…]}`; reads route by response key (`UserShard` vs legacy `PostsFeedState`). Stays on legacy contract until a real VK is known → additive & reversible.
- **Build** (`Makefile.toml`): copies the **raw** compiled wasm (not the packaged `build/freenet` container — the node re-hashes `data` to derive the key, only the raw wasm's blake3 == the code hash) to `web/public/user_shard.wasm` + injects `__USER_SHARD_CODE_HASH__`.

## Why the derivation is the load-bearing bit

If the JS derivation drifts from the node, every GET/PUT silently addresses a different (empty) contract — no error, just nothing. Pinned by a **ground-truth vector** in `shard-key.test.ts` taken from `fdev get-contract-id --code … --parameters …` (code hash `7iSNUfGW…`, 32×`0x01` → `2q69AnoP…`).

## Tests / gate

- `cargo fmt --check` ✓, `clippy --workspace --all-targets -D warnings` ✓, `cargo test --workspace` ✓ (0 failures)
- `tsc --noEmit` ✓, `vitest` ✓ (35, incl. the derivation vector + ContractKey/instance-id agreement)
- offline `vite build` ✓ — bundles blake3/bs58, emits `dist/user_shard.wasm` whose `b3sum` equals the injected code hash

## Not covered

The PUT-container / GET-by-derived-key **round-trip** is only exercisable against a live node (deferred WASM-in-node tier), not per-PR CI. The unit-tested invariant is the derivation match — the one thing that, if wrong, makes everything silently no-op.