### PR TITLE
fix: holistic shard review — GET serialization regression + test/doc gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,12 +203,21 @@ cd web && npm test                                 # Web app (Vitest)
 
 ## Contract migration
 
+> **Status: removed.** The migration system (issue #20, the `web/src/migrations/`
+> scaffold + the global posts/follows/likes contracts) was torn down in #33 when
+> the app cut over to shards-only. Nothing was deployed, so there was no state to
+> migrate. There is currently **no** migration loop and **no** `web/src/migrations/`
+> directory — do not look for those files. A per-identity migration flow (GET old
+> derived key → decode → re-inject under the new key) is expected to return once
+> shard contracts are versioned; track it under a future issue, not #20/#23.
+>
+> The schema-tolerance and build-isolation policies below STILL APPLY to the shard
+> contracts — they keep a future hash rotation migratable.
+
 A contract's WASM hash changes whenever its source or any WASM-affecting
 dependency changes, and the contract key is derived from that hash. So a bump
 moves every user's state to a new key — stranding the old state unless we
-migrate it. The migration system (issue #20) detects a bump on startup and
-pulls stranded state into the new key. It runs in `FreenetConnection.connect`
-(`web/src/freenet-api.ts`) before subscribing.
+migrate it.
 
 ### Schema-tolerance policy (MANDATORY)
 
@@ -244,33 +253,25 @@ hash — a rotation is always a deliberate edit.
 2. Keep the schema byte-compatible — additive serde-default fields only. A
    JSON-schema change in the same release would fail `validate_state` per user;
    split it out with a dedicated re-shape pass.
-3. `cargo make build-contracts` to regenerate the WASM + hashes.
-4. Append the **prior** hash (the previous current-hash value) to that
-   contract's legacy list in `web/src/migrations/legacy-hashes.ts`
-   (`LEGACY_POSTS_CODE_HASHES` / `LEGACY_FOLLOWS_CODE_HASHES` /
-   `LEGACY_LIKES_CODE_HASHES`). Append-only, oldest → newest — never reorder or
-   delete. The new current hash MUST NOT appear in the legacy list (enforced by
-   `legacy-hashes.test.ts`).
-5. Ship. On next load the migration loop GETs the old key, decodes its state,
-   and re-injects it under the new key.
+3. `cargo make build-contracts` to regenerate the WASM + hashes. The shard code
+   hashes are injected into the web build via `web/vite.config.ts`
+   (`__USER_SHARD_CODE_HASH__` / `__THREAD_SHARD_CODE_HASH__`); the raw WASM is
+   mirrored to `web/public/` with a `b3sum == code_hash` build-check
+   (`scripts/mirror-shard-wasm.sh`).
+4. Ship. Because nothing is deployed and there is no migration loop, a bump
+   currently strands no state. Once shards carry deployed state, a hash rotation
+   will need the per-identity migration flow described below (re-introduce it
+   before rotating a live shard).
 
-### Helpers
+### Deferred (per-identity migration — when shards carry deployed state)
 
-- `web/src/migrations/legacy-hashes.ts` — per-contract legacy lists + current
-  hashes (wired from `web/vite.config.ts`) + the `MIGRATABLE_CONTRACTS` registry.
-- `web/src/migrations/candidates.ts` — pure `buildMigrationCandidates` /
-  `selectMigrateFrom` (ported from mail `ui/src/inbox.rs`).
-- `web/src/migrations/state-store.ts` — `MigrationStateStore` (localStorage-
-  backed today; a delegate-backed store swaps in for the per-identity era).
-- `web/src/migrations/run.ts` — `runMigrations`, the startup loop.
-
-### Deferred (per-identity — lands with #11/#13)
-
-Once profile/posts contracts become per-identity, extend the identity delegate's
-secret storage with a `{ contract_type → recorded_hash }` map (mirroring mail's
-`AliasInfo`) and run the same `selectMigrateFrom` / candidate-chain / re-inject
-flow against each identity's derived key. Cross-version contact interop follows
-then.
+Re-introduce a migration flow: extend the identity delegate's secret storage
+with a `{ shard_type → recorded_hash }` map (mirroring mail's `AliasInfo`), and
+on startup GET each identity's prior derived key, decode its state, and re-inject
+it under the new key (a shard PUT-of-existing runs the CRDT merge, so re-injection
+is convergent, not an overwrite). Track under a fresh issue — issue #20 and its
+follow-up #23 covered the now-deleted global-contract migration runtime and are
+obsolete.
 
 ## Contract correctness invariants (review checklist)
 
@@ -369,7 +370,8 @@ un-parameterized shard accepts nothing — a safe default, not a footgun).
 
 - All Freenet protocol messages use FlatBuffers types from the stdlib
 - Contract state is JSON-encoded, transported as `Uint8Array`
-- Delta updates are JSON arrays of post/action objects
+- Delta updates are externally-tagged enums (`ShardDelta` `{"Posts":[…]}`/`{"Op":…}`,
+  `ThreadDelta` `{"Likes":[…]}`/`{"Replies":…}`/`{"Quotes":…}`, `InboxDelta`), JSON-encoded — not bare arrays
 - WebSocket URL pattern: `ws://{host}/contract/command`
 - Contract keys derived from instance ID via `ContractKey.fromInstanceId()`
 - CSS follows BEM naming: `block__element--modifier`

--- a/README.md
+++ b/README.md
@@ -3,22 +3,24 @@
 Freenet Microblogging is a decentralized Twitter/X-like application built on
 [Freenet](https://freenet.org), designed to provide censorship-resistant social networking where
 users own their data. It features a web-based interface built with TypeScript and Vite, Rust/WASM
-contracts for post storage and social graph, and an Ed25519 identity delegate for cryptographic
-signing.
+per-user/per-thread shard contracts for posts, social graph, replies, likes and notifications, and
+an ML-DSA-65 (post-quantum) identity delegate for cryptographic signing.
 
 ![Screenshot of microblogging interface](docs/screenshot.png)
 
 ## Roadmap
 
-- [x] Posts contract with 280-character limit and content-hash deduplication
-- [x] Follows contract for social graph (follow/unfollow)
-- [x] Likes contract for post reactions
-- [x] Ed25519 identity delegate with keypair generation and signing
+- [x] User shard: owner-writes posts (windowed, content-addressed), profile (LWW), follows (per-key seq merge)
+- [x] Thread shard: anyone-writes replies, likes, quotes (each record self-verifying), per root post
+- [x] Inbox shard: anyone-writes notifications, owner-prunes via signed ops
+- [x] ML-DSA-65 (post-quantum) identity delegate with keypair generation and signing
 - [x] Web UI with feed, compose box, profile, sidebar, dark/light mode
 - [x] Onboarding flow with identity creation and import
 - [x] Real-time post updates via contract subscription
-- [ ] Wire likes to contract (currently local-only)
-- [ ] Wire follows to contract (Following tab exists but empty)
+- [x] Wire posts + likes to shard contracts (user shard / thread shard)
+- [ ] Wire follows UI to the user shard (Following tab exists but empty)
+- [ ] Wire replies UI + delegate reply signing to the thread shard
+- [ ] Wire notifications UI to the inbox shard
 - [ ] Post search and filtering
 - [ ] Media attachments
 - [ ] GhostKey support for anonymous posting
@@ -138,12 +140,20 @@ on demand by the web app (no global publish). See [docs/adr/0001-implementation-
 
 ### Identity Delegate
 
-The identity delegate runs client-side in the Freenet node and manages Ed25519 keypairs. It supports:
+The identity delegate runs client-side in the Freenet node and manages ML-DSA-65 (post-quantum)
+keypairs. It is the single trusted encoder of canonical signing payloads — it builds each payload
+in Rust via the `common` crate and signs it, so the browser never assembles signed bytes itself.
+It supports:
 
 - **CreateIdentity**: Generate a new keypair with display name
 - **GetIdentity**: Retrieve the current identity
-- **SignPost**: Sign post content for authenticity
-- **ExportIdentity / ImportIdentity**: Transfer identity between devices
+- **SignPost**: Sign post content for authenticity (assigns the content-addressed post id)
+- **SignLike**: Sign a like/unlike record bound to a thread's root post id
+- **ExportIdentity / ImportIdentity**: Transfer identity between devices (64-hex seed)
+
+Reply signing (a `SignPost` with a non-empty `reply_to`) and notification delivery are not yet
+wired from the UI — the thread shard verifies replies and the inbox shard accepts notifications,
+but the client cutover for those surfaces lands in later ADR-0001 Phase 4 slices.
 
 The delegate key is computed as `BLAKE3(BLAKE3(wasm_bytes))` with empty parameters, and the code
 hash as `BLAKE3(wasm_bytes)`. Both are required for the node to locate the delegate in its store.

--- a/common/src/inbox.rs
+++ b/common/src/inbox.rs
@@ -248,6 +248,28 @@ mod test {
     }
 
     #[test]
+    fn golden_notif_signing_payload() {
+        // GOLDEN VECTOR — a change here means the signing format changed and ALL
+        // deployed notification signatures (and their content-addressed ids)
+        // break. Do not "fix" by updating the literal unless that break is
+        // intended and versioned (bump NOTIF_DOMAIN_TAG). Injectivity tests do
+        // not catch a consistent sign+verify format shift.
+        let n = Notification {
+            kind: NotifKind::Reply,
+            sender_pubkey: "aabbcc".into(),
+            ref_id: "post1".into(),
+            seq: 9,
+            writer_cert: None,
+            signature: None,
+        };
+        let expected = "14000000726176656e3a696e626f782d6e6f7469663a763109000000726563697069\
+            656e74050000007265706c790600000061616262636305000000706f737431080000000900000000\
+            000000";
+        let expected: String = expected.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(hex::encode(n.signing_payload("recipient")), expected);
+    }
+
+    #[test]
     fn decodes_old_shape_records() {
         // Missing ref_id/signature/writer_cert + an unknown forward field must decode.
         let n: Notification =

--- a/common/src/post.rs
+++ b/common/src/post.rs
@@ -317,6 +317,54 @@ mod test {
     }
 
     #[test]
+    fn golden_signing_payload_top_level() {
+        // GOLDEN VECTOR — a change here means the signing format changed and ALL
+        // deployed signatures/records break. Do not "fix" by updating the literal
+        // unless that break is intended and versioned (bump POST_DOMAIN_TAG).
+        //
+        // Existing tests only prove injectivity (length-prefix unambiguity); a
+        // serde/encoding change that shifts the payload CONSISTENTLY across
+        // sign+verify passes them yet silently invalidates already-deployed
+        // signatures. This pins the exact bytes as a tripwire.
+        let p = Post {
+            id: String::new(),
+            author_pubkey: "00112233".into(),
+            author_name: "Alice".into(),
+            author_handle: "@alice".into(),
+            content: "hello".into(),
+            timestamp: 1_700_000_000_000,
+            reply_to: String::new(),
+            signature: None,
+        };
+        let expected = "0d000000726176656e3a706f73743a763108000000303031313232333305000000\
+            416c6963650600000040616c6963650500000068656c6c6f080000000068e5cf8b010000";
+        let expected: String = expected.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(hex::encode(p.signing_payload()), expected);
+    }
+
+    #[test]
+    fn golden_signing_payload_reply() {
+        // GOLDEN VECTOR — see golden_signing_payload_top_level. This pins the
+        // reply variant (non-empty reply_to appended). Do not update the literal
+        // unless the format break is intended and POST_DOMAIN_TAG is bumped.
+        let p = Post {
+            id: String::new(),
+            author_pubkey: "00112233".into(),
+            author_name: "Alice".into(),
+            author_handle: "@alice".into(),
+            content: "hello".into(),
+            timestamp: 1_700_000_000_000,
+            reply_to: "rootid".into(),
+            signature: None,
+        };
+        let expected = "0d000000726176656e3a706f73743a763108000000303031313232333305000000\
+            416c6963650600000040616c6963650500000068656c6c6f080000000068e5cf8b010000\
+            06000000726f6f746964";
+        let expected: String = expected.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(hex::encode(p.signing_payload()), expected);
+    }
+
+    #[test]
     fn decodes_old_shape_without_signature() {
         // A post missing `signature` (older shape) and carrying an unknown
         // forward-compat field must decode.

--- a/common/src/signed_op.rs
+++ b/common/src/signed_op.rs
@@ -304,6 +304,33 @@ mod test {
     }
 
     #[test]
+    fn golden_signing_payload() {
+        // GOLDEN VECTOR — a change here means the signing format changed and ALL
+        // deployed SignedOp signatures break. Do not "fix" by updating the literal
+        // unless that break is intended and versioned (bump SIGNED_OP_DOMAIN_TAG
+        // and/or the affected shard context tag).
+        //
+        // Pins the exact bytes for a fixed op (Profile, payload "hi", seq 7,
+        // signer "aabbcc") under USER_SHARD_CONTEXT — the injectivity tests do
+        // not catch a consistent format shift across sign+verify.
+        let op = SignedOp {
+            op_type: OpType::Profile,
+            payload: b"hi".to_vec(),
+            seq: 7,
+            signer_pubkey: "aabbcc".into(),
+            signature: None,
+        };
+        let expected = "12000000726176656e3a7369676e65642d6f703a763113000000726176656e3a7573\
+            65722d73686172643a76310700000070726f66696c65020000006869080000000700000000000000\
+            06000000616162626363";
+        let expected: String = expected.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(
+            hex::encode(op.signing_payload(USER_SHARD_CONTEXT)),
+            expected
+        );
+    }
+
+    #[test]
     fn decodes_old_shape_op() {
         // Missing signature + unknown forward field must decode.
         let json = r#"{

--- a/common/src/thread.rs
+++ b/common/src/thread.rs
@@ -280,6 +280,42 @@ mod test {
     }
 
     #[test]
+    fn golden_like_signing_payload() {
+        // GOLDEN VECTOR — a change here means the signing format changed and ALL
+        // deployed like signatures break. Do not "fix" by updating the literal
+        // unless that break is intended and versioned (bump LIKE_DOMAIN_TAG).
+        // Injectivity tests do not catch a consistent sign+verify format shift.
+        let r = LikeRecord {
+            signer_pubkey: "aabbcc".into(),
+            seq: 3,
+            liked: true,
+            writer_cert: None,
+            signature: None,
+        };
+        let expected = "14000000726176656e3a7468726561642d6c696b653a76310b000000726f6f745f74\
+            6872656164060000006161626263630800000003000000000000000100000001";
+        let expected: String = expected.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(hex::encode(r.signing_payload("root_thread")), expected);
+    }
+
+    #[test]
+    fn golden_quote_signing_payload() {
+        // GOLDEN VECTOR — a change here means the signing format changed and ALL
+        // deployed quote-ref signatures break. Do not "fix" by updating the literal
+        // unless that break is intended and versioned (bump QUOTE_DOMAIN_TAG).
+        let q = QuoteRef {
+            signer_pubkey: "aabbcc".into(),
+            quote_post_id: "qid".into(),
+            writer_cert: None,
+            signature: None,
+        };
+        let expected = "15000000726176656e3a7468726561642d71756f74653a76310b000000726f6f745f\
+            7468726561640600000061616262636303000000716964";
+        let expected: String = expected.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(hex::encode(q.signing_payload("root_thread")), expected);
+    }
+
+    #[test]
     fn decodes_old_shape_records() {
         // Missing signature/writer_cert + unknown forward field must decode.
         let like: LikeRecord =

--- a/contracts/inbox-shard/src/lib.rs
+++ b/contracts/inbox-shard/src/lib.rs
@@ -1196,6 +1196,43 @@ mod test {
     }
 
     #[test]
+    fn state_and_delta_merges_both() {
+        // The StateAndDelta update arm: one update item carrying a full state AND
+        // a delta. update_state must merge_state the state THEN apply the delta,
+        // so a record from each is present and post-merge invariants hold.
+        // Full state: a notif (seq 5) + a genuine owner-signed PruneBefore (seq 2).
+        let from_state = signed_notif([2u8; 32], NotifKind::Reply, "from-state", 5);
+        let mut src = InboxShard::default();
+        src.notifs
+            .insert(from_state.id(&owner_vk()), from_state.clone());
+        src.prune_before_op = Some(prune_op(OpType::PruneBefore, Vec::new(), 2));
+        // Delta: a second notif (seq 6, above the high-water) on the notif surface.
+        let from_delta = signed_notif([3u8; 32], NotifKind::Quote, "from-delta", 6);
+        let delta = serde_json::to_vec(&InboxDelta::Notifs(vec![from_delta.clone()])).unwrap();
+
+        let out = run_update(
+            InboxShard::default(),
+            vec![UpdateData::StateAndDelta {
+                state: state_of(&src),
+                delta: StateDelta::from(delta),
+            }],
+        );
+        // Both notifs present (state's + delta's), each above the high-water.
+        assert_eq!(out.notifs.len(), 2, "state notif + delta notif both merged");
+        assert!(out.notifs.contains_key(&from_state.id(&owner_vk())));
+        assert!(out.notifs.contains_key(&from_delta.id(&owner_vk())));
+        // State's owner-signed high-water survived the merge.
+        assert_eq!(pruned_before(&out), 2);
+        // Invariants: every notif keyed under its own content address and at or
+        // above the high-water (the admission rule normalize enforces post-merge).
+        let hw = pruned_before(&out);
+        for (id, n) in &out.notifs {
+            assert_eq!(id, &n.id(&owner_vk()));
+            assert!(n.seq >= hw);
+        }
+    }
+
+    #[test]
     fn prune_ids_payload_round_trips() {
         let ids = vec!["aaa".to_string(), "bbb".to_string(), "ccc".to_string()];
         let encoded = encode_prune_ids(&ids);

--- a/contracts/thread-shard/src/lib.rs
+++ b/contracts/thread-shard/src/lib.rs
@@ -700,6 +700,41 @@ mod test {
     }
 
     #[test]
+    fn state_and_delta_merges_both() {
+        // The StateAndDelta update arm: one update item carrying a full state AND
+        // a delta. update_state must merge_state the state THEN apply the delta,
+        // so a record from each is present and post-merge invariants hold.
+        // Full state: a reply + a like the peer already holds.
+        let mut src = ThreadShard::default();
+        let r = signed_reply([1u8; 32], "from-state", 100);
+        src.replies.insert(r.id.clone(), r.clone());
+        let lk = signed_like([2u8; 32], 1, true);
+        src.likes.insert(lk.signer_pubkey.clone(), lk);
+        // Delta: a quote (a distinct second record on a distinct surface).
+        let q = signed_quote([3u8; 32], "from-delta");
+        let delta = serde_json::to_vec(&ThreadDelta::Quotes(vec![q.clone()])).unwrap();
+
+        let out = run_update(
+            ThreadShard::default(),
+            vec![UpdateData::StateAndDelta {
+                state: state_of(&src),
+                delta: StateDelta::from(delta),
+            }],
+        );
+        // State's reply + like merged in.
+        assert_eq!(out.replies.len(), 1, "state reply merged");
+        assert!(out.replies.contains_key(&r.id));
+        assert_eq!(out.likes.len(), 1, "state like merged");
+        // Delta's quote merged in.
+        assert_eq!(out.quotes.len(), 1, "delta quote merged");
+        assert!(out.quotes.contains_key("from-delta"));
+        // Invariant: every reply still keyed under its own content address.
+        for (id, reply) in &out.replies {
+            assert_eq!(id, &reply.id);
+        }
+    }
+
+    #[test]
     fn validate_rejects_misfiled_reply_id() {
         let mut shard = ThreadShard::default();
         let r = signed_reply([1u8; 32], "x", 100);

--- a/contracts/user-shard/src/lib.rs
+++ b/contracts/user-shard/src/lib.rs
@@ -954,6 +954,56 @@ mod test {
     }
 
     #[test]
+    fn state_and_delta_merges_both() {
+        // The StateAndDelta update arm: a peer ships a full state AND a delta in
+        // one item. update_state must merge_state the state THEN apply the delta,
+        // so a record from each is present and post-merge invariants hold.
+        let owner = [1u8; 32];
+        let a = vk_hex([10u8; 32]);
+        // Full state: a post + a profile (seq 1) the peer already holds.
+        let src = apply(
+            owner,
+            empty_state(),
+            vec![
+                ShardDelta::Posts(vec![signed_post(owner, "from-state", 1)]),
+                ShardDelta::Op(profile_op(owner, &sample_profile(), 1)),
+            ],
+        );
+        // Delta: a follow op (a distinct second record on a distinct surface).
+        let delta = serde_json::to_vec(&ShardDelta::Op(follow_op(owner, &[&a], true, 1))).unwrap();
+
+        let res = UserShard::update_state(
+            params_of(owner),
+            State::from(empty_state()),
+            vec![UpdateData::StateAndDelta {
+                state: State::from(src),
+                delta: StateDelta::from(delta),
+            }],
+        )
+        .unwrap()
+        .unwrap_valid();
+        let shard: UserShard = serde_json::from_slice(res.as_ref()).unwrap();
+        // State's post merged in.
+        assert_eq!(shard.posts.len(), 1, "state post merged");
+        assert_eq!(shard.posts[0].content, "from-state");
+        // State's profile merged in.
+        assert_eq!(shard.profile.unwrap().profile.display_name, "Alice");
+        // Delta's follow merged in.
+        assert!(
+            shard.follows.get(&a).unwrap().following,
+            "delta follow merged"
+        );
+        // Canonical post order invariant: stored sorted by post_hash.
+        let mut sorted = shard.posts.clone();
+        sorted.sort_by_cached_key(post_hash);
+        assert_eq!(
+            shard.posts.iter().map(post_hash).collect::<Vec<_>>(),
+            sorted.iter().map(post_hash).collect::<Vec<_>>(),
+            "posts remain in canonical merge order"
+        );
+    }
+
+    #[test]
     fn validate_rejects_duplicate_ids() {
         let owner = [1u8; 32];
         let p = signed_post(owner, "dup", 1);

--- a/delegates/identity/src/lib.rs
+++ b/delegates/identity/src/lib.rs
@@ -125,6 +125,68 @@ fn vk_hex(signing_key: &MlDsaSigningKey<MlDsa65>) -> String {
     hex::encode(signing_key.verifying_key().encode())
 }
 
+/// Assemble the canonical [`Post`] and sign it with `signing_key`.
+///
+/// This is the trusted producer of the signatures the user-shard contract
+/// verifies via [`Post::verify`]: it populates `author_pubkey` with the hex VK,
+/// derives the content-addressed id with the single trusted encoder
+/// (`common::post`), then signs that exact payload. A top-level post keeps
+/// `reply_to` empty so the signing payload is byte-identical to the
+/// pre-`reply_to` shape. Pure (no `ctx` / secret store) so it is unit-testable
+/// on the host target, where the secret store is unavailable.
+fn build_signed_post(
+    signing_key: &MlDsaSigningKey<MlDsa65>,
+    content: &str,
+    author_name: &str,
+    author_handle: &str,
+    timestamp: u64,
+) -> Post {
+    let public_key = vk_hex(signing_key);
+    let mut post = Post {
+        id: String::new(),
+        author_pubkey: public_key,
+        author_name: author_name.to_string(),
+        author_handle: author_handle.to_string(),
+        content: content.to_string(),
+        timestamp,
+        // Top-level post: empty reply_to keeps the signing payload byte-identical
+        // to the pre-reply_to shape. Reply signing (non-empty reply_to) arrives
+        // with thread-shard UI wiring (ADR-0001 Phase 4).
+        reply_to: String::new(),
+        signature: None,
+    };
+    post.id = post.compute_id();
+    let signature: ml_dsa::Signature<MlDsa65> = signing_key.sign(&post.signing_payload());
+    post.signature = Some(hex::encode(signature.encode()));
+    post
+}
+
+/// Assemble the canonical [`LikeRecord`] and sign it for `root_post_id`.
+///
+/// The thread shard verifies these via [`LikeRecord::verify`]. The signing
+/// payload (built by the single trusted encoder, `common::thread`) binds the
+/// **thread root id**, so a like signed for one thread can never be replayed
+/// into another. Pure (no `ctx` / secret store) so it is unit-testable on the
+/// host target. Returns the record and its hex-encoded signature.
+fn build_signed_like(
+    signing_key: &MlDsaSigningKey<MlDsa65>,
+    root_post_id: &str,
+    seq: u64,
+    liked: bool,
+) -> (LikeRecord, String) {
+    let signer_pubkey = vk_hex(signing_key);
+    let record = LikeRecord {
+        signer_pubkey,
+        seq,
+        liked,
+        writer_cert: None,
+        signature: None,
+    };
+    let signature: ml_dsa::Signature<MlDsa65> =
+        signing_key.sign(&record.signing_payload(root_post_id));
+    (record, hex::encode(signature.encode()))
+}
+
 #[delegate]
 impl DelegateInterface for IdentityDelegate {
     fn process(
@@ -275,31 +337,16 @@ fn sign_post(
         }
         Err(resp) => return resp,
     };
-    let public_key = vk_hex(&signing_key);
 
-    // Build the canonical record and derive its content-addressed id with the
-    // single trusted encoder (`common::post`), then sign that exact payload.
-    let mut post = Post {
-        id: String::new(),
-        author_pubkey: public_key.clone(),
-        author_name: author_name.to_string(),
-        author_handle: author_handle.to_string(),
-        content: content.to_string(),
-        timestamp,
-        // Top-level post: empty reply_to keeps the signing payload byte-identical
-        // to the pre-reply_to shape. Reply signing (non-empty reply_to) arrives
-        // with thread-shard UI wiring (ADR-0001 Phase 4).
-        reply_to: String::new(),
-        signature: None,
-    };
-    post.id = post.compute_id();
-    let signature: ml_dsa::Signature<MlDsa65> = signing_key.sign(&post.signing_payload());
+    // Build + sign the canonical record with the single trusted encoder
+    // (`common::post`) — the exact bytes the user-shard contract verifies.
+    let post = build_signed_post(&signing_key, content, author_name, author_handle, timestamp);
 
     Response::Signed {
         nonce: nonce.to_string(),
         post_id: post.id,
-        signature: hex::encode(signature.encode()),
-        public_key,
+        signature: post.signature.unwrap_or_default(),
+        public_key: post.author_pubkey,
     }
 }
 
@@ -322,27 +369,19 @@ fn sign_like(
         }
         Err(resp) => return resp,
     };
-    let signer_pubkey = vk_hex(&signing_key);
 
-    // Build the canonical record and sign its payload with the single trusted
-    // encoder (`common::thread`) — the same bytes the thread shard verifies.
-    let record = LikeRecord {
-        signer_pubkey: signer_pubkey.clone(),
-        seq,
-        liked,
-        writer_cert: None,
-        signature: None,
-    };
-    let signature: ml_dsa::Signature<MlDsa65> =
-        signing_key.sign(&record.signing_payload(root_post_id));
+    // Build + sign the canonical record with the single trusted encoder
+    // (`common::thread`) — the same bytes the thread shard verifies, bound to
+    // the thread root id.
+    let (record, signature) = build_signed_like(&signing_key, root_post_id, seq, liked);
 
     Response::SignedLike {
         nonce: nonce.to_string(),
         root_post_id: root_post_id.to_string(),
-        signer_pubkey,
+        signer_pubkey: record.signer_pubkey,
         seq,
         liked,
-        signature: hex::encode(signature.encode()),
+        signature,
     }
 }
 
@@ -402,5 +441,234 @@ fn import_identity(ctx: &mut DelegateCtx, secret_key_hex: &str, display_name: &s
         public_key,
         handle,
         display_name: display_name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    //! Why these tests live here and not against `process()`:
+    //!
+    //! `process()` — and therefore the public `sign_post` / `sign_like` /
+    //! `export_identity` / `import_identity` entry points — reads and writes the
+    //! signer's seed through `DelegateCtx::{get_secret, set_secret}`. Those are
+    //! WASM host imports; on the host test target the stdlib stubs them to return
+    //! `None` / `false` (see `freenet_stdlib::delegate_host`). So a host-driven
+    //! `process()` call can never load a key and always returns the "no identity
+    //! found" error — it is genuinely undrivable off-WASM.
+    //!
+    //! What matters for on-network correctness is that the bytes the delegate
+    //! signs are the *same* bytes the contracts verify. That logic — payload
+    //! assembly, field population, id derivation, signature encoding — lives in
+    //! the pure `build_signed_post` / `build_signed_like` / `signing_key_from_seed`
+    //! / `vk_hex` helpers, which `sign_post` / `sign_like` / `export` / `import`
+    //! call verbatim. These tests exercise those exact helpers and then verify the
+    //! result with the SAME `common` verify code the contracts run, so a
+    //! divergence between signer and verifier fails here rather than on-network.
+    use super::*;
+    use freenet_microblogging_common::post::VerifyError as PostVerifyError;
+    use freenet_microblogging_common::thread::VerifyError as ThreadVerifyError;
+
+    const SEED_A: [u8; MLDSA_SEED_LEN] = [7u8; MLDSA_SEED_LEN];
+    const SEED_B: [u8; MLDSA_SEED_LEN] = [42u8; MLDSA_SEED_LEN];
+
+    // 1. export → import round-trip of the 64-hex secret seed yields the same
+    //    signing key / VK. Mirrors `export_identity` (hex::encode(seed)) feeding
+    //    `import_identity` (hex::decode → try_into → signing_key_from_seed).
+    #[test]
+    fn export_import_seed_roundtrip_preserves_key() {
+        let original = signing_key_from_seed(&SEED_A);
+        let exported_hex = hex::encode(SEED_A); // what export_identity emits
+
+        // 32-byte seed → 64 hex chars (the documented ImportIdentity contract).
+        assert_eq!(exported_hex.len(), MLDSA_SEED_LEN * 2);
+
+        // what import_identity does with the hex string.
+        let decoded = hex::decode(&exported_hex).expect("valid hex");
+        let reimported_seed: [u8; MLDSA_SEED_LEN] =
+            decoded.as_slice().try_into().expect("32 bytes");
+        let reimported = signing_key_from_seed(&reimported_seed);
+
+        assert_eq!(reimported_seed, SEED_A);
+        // Same VK after the full export→import cycle.
+        assert_eq!(vk_hex(&reimported), vk_hex(&original));
+    }
+
+    // 2. sign_post: the delegate's assembled Post + signature VERIFIES under
+    //    common's `Post::verify` — the same code the user-shard contract runs.
+    //    Confirms field population (author_pubkey casing, empty reply_to) matches
+    //    what the verifier reconstructs.
+    #[test]
+    fn signed_post_verifies_under_common() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let post = build_signed_post(&sk, "hello raven", "Alice", "@alice", 1_700_000_000_000);
+
+        // The contract's acceptance check passes on the delegate's output.
+        assert_eq!(post.verify(), Ok(()));
+
+        // Field population the verifier depends on.
+        assert_eq!(post.author_pubkey, vk_hex(&sk)); // exact hex VK, lowercase
+        assert!(post.reply_to.is_empty()); // top-level post
+        assert_eq!(post.author_name, "Alice");
+        assert_eq!(post.author_handle, "@alice");
+        assert_eq!(post.content, "hello raven");
+        assert_eq!(post.timestamp, 1_700_000_000_000);
+        // id is the content address of the signed payload.
+        assert!(post.id_is_valid());
+        assert!(post.signature.is_some());
+    }
+
+    // 2b. A post signed by one key must NOT verify if the author_pubkey is
+    //     swapped to a different key — guards against the delegate emitting a VK
+    //     that does not match the signing key.
+    #[test]
+    fn signed_post_rejects_mismatched_author_key() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let mut post = build_signed_post(&sk, "hello", "Alice", "@alice", 1);
+        // Swap in a different author key (recompute id so we isolate the
+        // signature check rather than tripping the id-mismatch guard first).
+        post.author_pubkey = vk_hex(&signing_key_from_seed(&SEED_B));
+        post.id = post.compute_id();
+        assert_eq!(post.verify(), Err(PostVerifyError::SignatureInvalid));
+    }
+
+    // 3. sign_like: the delegate's LikeRecord signature verifies under common's
+    //    thread verify, and is bound to the THREAD root_post_id. A cross-context
+    //    mix-up (verifying against a different root) MUST fail.
+    #[test]
+    fn signed_like_verifies_and_is_thread_bound() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let root = "root_post_content_address_abc";
+        let (record, sig_hex) = build_signed_like(&sk, root, 1, true);
+
+        // Reassemble the on-wire record exactly as the UI folds it into the
+        // thread shard (signer_pubkey + seq + liked + the hex signature), then
+        // run the contract's verify.
+        let wire = LikeRecord {
+            signer_pubkey: record.signer_pubkey.clone(),
+            seq: record.seq,
+            liked: record.liked,
+            writer_cert: None,
+            signature: Some(sig_hex),
+        };
+        assert_eq!(wire.verify(root), Ok(()));
+
+        // Field population.
+        assert_eq!(wire.signer_pubkey, vk_hex(&sk));
+        assert_eq!(wire.seq, 1);
+        assert!(wire.liked);
+
+        // Thread binding: the same signed like must NOT verify under a different
+        // root id (cross-thread replay defense).
+        assert_eq!(
+            wire.verify("a_completely_different_root"),
+            Err(ThreadVerifyError::SignatureInvalid)
+        );
+    }
+
+    // 3b. Cross-CONTEXT mix-up: a like is bound to the thread root id via the
+    //     LIKE_DOMAIN_TAG'd payload. Signing for the thread root then trying to
+    //     verify with the *inbox* identifier (a foreign context value) in the
+    //     root slot must fail — the signature does not transplant between the
+    //     thread context and any other context that reuses the verify call.
+    #[test]
+    fn signed_like_does_not_verify_in_foreign_context() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let thread_root = "thread:root_post_id_123";
+        let inbox_context = "inbox:recipient_pubkey_456"; // a non-thread identifier
+        let (record, sig_hex) = build_signed_like(&sk, thread_root, 5, true);
+
+        let wire = LikeRecord {
+            signer_pubkey: record.signer_pubkey,
+            seq: record.seq,
+            liked: record.liked,
+            writer_cert: None,
+            signature: Some(sig_hex),
+        };
+        // Verifies in its own thread context...
+        assert_eq!(wire.verify(thread_root), Ok(()));
+        // ...but a like signed for the thread cannot be replayed against any
+        // other context value occupying the root slot.
+        assert_eq!(
+            wire.verify(inbox_context),
+            Err(ThreadVerifyError::SignatureInvalid)
+        );
+    }
+
+    // 3c. seq / liked are signed: flipping either after signing breaks verify
+    //     (the delegate must sign exactly what it returns to the UI).
+    #[test]
+    fn signed_like_seq_and_flag_are_bound() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let root = "root_xyz";
+        let (record, sig_hex) = build_signed_like(&sk, root, 3, true);
+
+        let tampered_seq = LikeRecord {
+            signer_pubkey: record.signer_pubkey.clone(),
+            seq: 4, // bumped
+            liked: record.liked,
+            writer_cert: None,
+            signature: Some(sig_hex.clone()),
+        };
+        assert_eq!(
+            tampered_seq.verify(root),
+            Err(ThreadVerifyError::SignatureInvalid)
+        );
+
+        let tampered_flag = LikeRecord {
+            signer_pubkey: record.signer_pubkey,
+            seq: 3,
+            liked: false, // flipped like→unlike
+            writer_cert: None,
+            signature: Some(sig_hex),
+        };
+        assert_eq!(
+            tampered_flag.verify(root),
+            Err(ThreadVerifyError::SignatureInvalid)
+        );
+    }
+
+    // 4. vk_hex encoding equals what the shard owner-param match expects: the
+    //    lowercase hex of the raw VK bytes, and it round-trips back to the same
+    //    VK bytes the verifier decodes.
+    #[test]
+    fn vk_hex_is_hex_of_raw_vk_bytes() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let encoded = sk.verifying_key().encode();
+        let expected = hex::encode(encoded.as_slice());
+
+        let got = vk_hex(&sk);
+        assert_eq!(got, expected);
+        // ML-DSA-65 VK is 1952 bytes → 3904 hex chars (per the Response docs).
+        assert_eq!(got.len(), 1952 * 2);
+        // Lowercase hex (owner-param matching is byte-for-byte string equality).
+        assert_eq!(got, got.to_lowercase());
+        // Round-trips back to the same raw bytes the verifier decodes.
+        assert_eq!(hex::decode(&got).expect("valid hex"), encoded.as_slice());
+    }
+
+    // 5. seed → key determinism: the same seed always yields the same VK, and
+    //    two distinct seeds yield distinct VKs. This is the property `export` /
+    //    `import` and cross-device restore rely on.
+    #[test]
+    fn seed_to_key_is_deterministic() {
+        let a1 = vk_hex(&signing_key_from_seed(&SEED_A));
+        let a2 = vk_hex(&signing_key_from_seed(&SEED_A));
+        let b = vk_hex(&signing_key_from_seed(&SEED_B));
+
+        assert_eq!(a1, a2, "same seed must yield the same VK");
+        assert_ne!(a1, b, "distinct seeds must yield distinct VKs");
+    }
+
+    // Cross-check: a post and a like signed by the SAME key are domain-separated,
+    // so neither signature can be replayed as the other structure. (Guards the
+    // delegate's two signing paths against payload collision.)
+    #[test]
+    fn post_and_like_payloads_are_domain_separated() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let post = build_signed_post(&sk, "x", "n", "h", 0);
+        let (like, _) = build_signed_like(&sk, "root", 0, true);
+        // Distinct domain tags (raven:post:v1 vs raven:thread-like:v1) guarantee
+        // the byte payloads differ.
+        assert_ne!(post.signing_payload(), like.signing_payload("root"));
     }
 }

--- a/docs/adr/0001-implementation-notes.md
+++ b/docs/adr/0001-implementation-notes.md
@@ -530,6 +530,39 @@ it now also mirrors the raw wasm to `web/public/` and runs the b3sum check).
   skip the PUT and the first like's UPDATE would no-op. This is the key thing the
   deferred real-node test must confirm.
 
+## Post-cutover holistic review (fixes)
+
+A whole-system review after the teardown (#33) — reading all three shards + the
+delegate + the web client together, rather than one PR diff — surfaced fixes the
+per-slice reviews could not see:
+
+- **GET-response serialization (regression introduced by the teardown).** The
+  stdlib resolves GET promises from a single uncorrelated FIFO queue: the Nth
+  response settles the Nth pending `get()`, regardless of contract. The slice-1
+  `startupDone` barrier covered only startup-time traffic, which #33 removed — so
+  post-cutover the barrier serialized nothing while *multiple* shard flows
+  (user-shard probe/load, per-thread probe/like-refresh) were live at once. Two
+  in-flight GETs could swap responses: a thread GET resolving the user-shard probe
+  (feed never instantiates) or a like-refresh popping a thread probe (that thread
+  never PUT → the like is silently lost). Replaced the barrier with
+  `serializedGet` (`web/src/freenet-api.ts`): every `api.get()` chains behind the
+  previous one's settle, so at most one GET is outstanding and each response
+  matches its own promise. Pinned by `web/src/freenet-api.test.ts`.
+- **Lost-like revert (M-3).** `ensureThreadShard` now awaits its PUT before the
+  caller sends the like UPDATE (an UPDATE to a never-instantiated contract is
+  dropped by the node), and `completeLike` re-GETs the authoritative aggregate on
+  UPDATE *failure* too, so the optimistic toggle is always reconciled away rather
+  than left stuck.
+- **Fabricated-engagement / dangling threads (H-3) — accepted + mitigated.** A
+  thread shard is keyed by a post id but the contract never checks the root post
+  is real, and a post evicted from the user-shard window (`MAX_POSTS`) leaves its
+  thread shard's likes orphaned. The client mitigation is already in place:
+  `onLikeUpdated` ignores aggregates for any post not in the live feed
+  (`index.ts`), and a post id is the blake3 of its own signed content, so an
+  attacker cannot pre-seed a *real* future post's thread. Residual: a like
+  aggregate trusts only the records present in the addressed thread shard; treat a
+  thread aggregate as authoritative only while its root post is in view.
+
 ## Testing tiers
 
 - **Unit** — per-function `#[test]`s inside each contract crate's `test` module:
@@ -552,8 +585,17 @@ it now also mirrors the raw wasm to `web/public/` and runs the b3sum check).
   WASM-compilation or transport differences. A real-node tier (via the
   `freenet:linux-test` / `freenet:local-dev` skills — publish the shards, drive
   reply/like/quote + two-peer sync over the live WS) is the next testing slice;
-  it is heavier and not a per-PR CI fit. The identity delegate also still lacks
-  unit coverage (deferred from Phase 0).
+  it is heavier and not a per-PR CI fit. It is the only tier that can confirm the
+  load-bearing `ensureThreadShard` GET-rejects-on-uninstantiated assumption above
+  and catch WASM-trap / node-vs-JS key-derivation drift. **Tracked as issue #34**
+  (not only this note).
+- **Delegate unit coverage (added in the holistic-review pass).** The identity
+  delegate now has unit tests (`delegates/identity/src/lib.rs`): export→import seed
+  round-trip, and the delegate's `SignPost`/`SignLike` outputs verify under the
+  same `common` code the contracts run (thread-context binding, vk_hex == owner
+  param). The end-to-end `process()` request path stays uncovered on the host
+  target (its secret store is a WASM-only host import) — exercised only by the
+  WASM-in-node tier above.
 
 `cargo make test` now runs `cargo test --workspace` (was a hand-maintained subset
 that omitted the user/thread shards and the delegate) so every crate — and these

--- a/docs/adr/0001-implementation-notes.md
+++ b/docs/adr/0001-implementation-notes.md
@@ -548,6 +548,15 @@ per-slice reviews could not see:
   `serializedGet` (`web/src/freenet-api.ts`): every `api.get()` chains behind the
   previous one's settle, so at most one GET is outstanding and each response
   matches its own promise. Pinned by `web/src/freenet-api.test.ts`.
+  - **Subtlety (caught in review):** the chain must advance on the UNDERLYING
+    `api.get()` settle, NOT on the app's soft timeout. The stdlib keeps a GET in
+    its `pendingGets` FIFO until a real response/NotFound or its own 30 s
+    `REQUEST_TIMEOUT_MS`. A shorter (8 s) app timeout that advanced the chain
+    would issue the next GET while the stale entry is still queued → two entries
+    → a late response pops the wrong promise (the same misroute). So
+    `serializedGet` chains on the raw stdlib promise and exposes the 8 s only as
+    a soft caller-facing view that does not release the next GET. Regression
+    guard: `does NOT advance the chain on the soft timeout`.
 - **Lost-like revert (M-3).** `ensureThreadShard` now awaits its PUT before the
   caller sends the like UPDATE (an UPDATE to a never-instantiated contract is
   dropped by the node), and `completeLike` re-GETs the authoritative aggregate on

--- a/web/src/freenet-api.test.ts
+++ b/web/src/freenet-api.test.ts
@@ -231,6 +231,41 @@ describe("FreenetConnection", () => {
       await flush();
       expect(api.getCalls.length).toBe(2);
     });
+
+    // Regression guard for H-A (skeptical review of PR #35): the soft 8 s app
+    // timeout MUST NOT advance the chain, because the stdlib keeps the timed-out
+    // GET in its `pendingGets` FIFO until a real response or its OWN 30 s reject.
+    // If the chain advanced on the soft timeout, the next api.get() would be
+    // issued while the stale entry is still queued → two entries → a late
+    // response pops the wrong promise (the misroute this fix exists to prevent).
+    it("does NOT advance the chain on the soft timeout — only on the real GET settle", async () => {
+      vi.useFakeTimers();
+      try {
+        const { conn, api } = makeConnection();
+
+        conn.setUser(OWNER_VK, "Alice", "alice"); // probe GET in flight
+        await vi.advanceTimersByTimeAsync(0);
+        expect(api.getCalls.length).toBe(1);
+
+        // A second serialised GET is queued behind the (still-unsettled) probe.
+        conn.loadState();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(api.getCalls.length).toBe(1);
+
+        // Fire the 8 s soft timeout WITHOUT settling the underlying GET. The
+        // stdlib entry is still live; the chain must stay blocked.
+        await vi.advanceTimersByTimeAsync(8000);
+        expect(api.getCalls.length).toBe(1); // 2nd GET still NOT issued
+
+        // Only once the real (late) GET settles does the chain advance.
+        api.getCalls[0].resolve({} as GetResponse);
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(api.getCalls.length).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("dropPendingLike — nonce matching", () => {

--- a/web/src/freenet-api.test.ts
+++ b/web/src/freenet-api.test.ts
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { GetRequest, GetResponse } from "@freenetorg/freenet-stdlib";
+
+// ---------------------------------------------------------------------------
+// Mocking approach
+// ---------------------------------------------------------------------------
+// freenet-api.ts builds its WebSocket client from the stdlib's `FreenetWsApi`
+// inside connect(). Every OTHER stdlib symbol it (and shard-key.ts) uses —
+// ContractKey, GetRequest, WasmContractV1, the flatbuffer tables — must stay
+// REAL, because shard-key.ts derives genuine ContractKeys and the production
+// code routes GET responses by `key.encode()`. So we do a PARTIAL mock: keep
+// `...actual`, and replace only `FreenetWsApi` with a fake whose constructor
+// captures the ResponseHandler and whose `.get()` returns deferred promises we
+// settle by hand. That lets us drive the client state machine deterministically
+// without a node, while real keys still match real responses.
+//
+// `./identity` is mocked too: likePost/publishPost call signLike/signPost,
+// which only succeed when a delegate is connected. We stub them to report
+// "delegate connected" so those flows proceed without a real delegate.
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+  req: GetRequest;
+}
+
+// The FakeWsApi class must be defined inside vi.hoisted, because vi.mock's
+// factory is hoisted to the very top of the module — referencing a normal
+// top-level class there throws "Cannot access before initialization". Anything
+// the factory closes over has to come from vi.hoisted (which runs first).
+const { FakeWsApi } = vi.hoisted(() => {
+  function deferred<T>(req: GetRequest): Deferred<T> {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject, req };
+  }
+
+  /** Fake FreenetWsApi: records calls, hands back controllable GET promises. */
+  class FakeWsApi {
+    static instances: FakeWsApi[] = [];
+    handler: import("@freenetorg/freenet-stdlib").ResponseHandler;
+    getCalls: Deferred<GetResponse>[] = [];
+    putCalls: unknown[] = [];
+    updateCalls: unknown[] = [];
+    subscribeCalls: unknown[] = [];
+    /** When set, update() rejects with this — to exercise completeLike's catch. */
+    updateError: Error | null = null;
+
+    constructor(
+      _url: URL,
+      handler: import("@freenetorg/freenet-stdlib").ResponseHandler,
+      _token: string,
+    ) {
+      this.handler = handler;
+      FakeWsApi.instances.push(this);
+    }
+
+    get(req: GetRequest): Promise<GetResponse> {
+      const d = deferred<GetResponse>(req);
+      this.getCalls.push(d);
+      return d.promise;
+    }
+
+    put(req: unknown): Promise<void> {
+      this.putCalls.push(req);
+      return Promise.resolve();
+    }
+
+    update(req: unknown): Promise<void> {
+      this.updateCalls.push(req);
+      return this.updateError
+        ? Promise.reject(this.updateError)
+        : Promise.resolve();
+    }
+
+    subscribe(req: unknown): Promise<void> {
+      this.subscribeCalls.push(req);
+      return Promise.resolve();
+    }
+  }
+  return { FakeWsApi };
+});
+
+type FakeWsApi = InstanceType<typeof FakeWsApi>;
+
+vi.mock("@freenetorg/freenet-stdlib", async (importActual) => {
+  const actual = await importActual<typeof import("@freenetorg/freenet-stdlib")>();
+  return { ...actual, FreenetWsApi: FakeWsApi };
+});
+
+// signPost/signLike normally require a connected delegate. Report connected so
+// likePost/publishPost proceed; we drive completeLike/completePublish directly.
+vi.mock("./identity", () => ({
+  signPost: vi.fn(() => true),
+  signLike: vi.fn(() => true),
+}));
+
+import { FreenetConnection, type FreenetCallbacks, type LikeState } from "./freenet-api";
+
+// A real ML-DSA-65 VK is 1952 bytes → 3904 hex chars; setUser only initialises
+// the user shard for a key of exactly that length (the offline 64-char fake is
+// rejected). Use a deterministic 3904-char hex owner.
+const OWNER_VK = "ab".repeat(1952);
+
+function makeConnection() {
+  const callbacks: {
+    onPostsLoaded: ReturnType<typeof vi.fn>;
+    onNewPost: ReturnType<typeof vi.fn>;
+    onStatusChange: ReturnType<typeof vi.fn>;
+    onLikeUpdated: ReturnType<typeof vi.fn>;
+  } = {
+    onPostsLoaded: vi.fn(),
+    onNewPost: vi.fn(),
+    onStatusChange: vi.fn(),
+    onLikeUpdated: vi.fn(),
+  };
+  const conn = new FreenetConnection(callbacks as unknown as FreenetCallbacks);
+  conn.connect();
+  const api = FakeWsApi.instances[FakeWsApi.instances.length - 1];
+  return { conn, api, callbacks };
+}
+
+/** Flush the microtask queue so chained `.then` callbacks run. */
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  FakeWsApi.instances = [];
+  vi.useRealTimers();
+  // connect() builds `ws://${location.host}/...`; the node test env has no DOM
+  // `location`. Stub a minimal one so the URL constructs and our FakeWsApi is
+  // reached. (Vitest's default env is `node`; we don't otherwise need a DOM.)
+  (globalThis as { location?: { host: string } }).location = {
+    host: "localhost:8080",
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as { location?: unknown }).location;
+});
+
+describe("FreenetConnection", () => {
+  describe("serializedGet — single GET in flight (H-1 anti-misroute guarantee)", () => {
+    // This is the core property the H-1 fix restores: at most one api.get() is
+    // outstanding, so the stdlib's uncorrelated FIFO response queue can never
+    // settle the wrong awaited promise. If serialisation regresses, two GETs
+    // overlap and responses can be swapped (feed never instantiates / likes
+    // silently lost).
+    it("does not issue the 2nd GET until the 1st settles", async () => {
+      const { conn, api } = makeConnection();
+
+      // Two independent GET-issuing flows started back-to-back: a user-shard
+      // load and a thread like-refresh. Both go through serializedGet.
+      conn.setUser(OWNER_VK, "Alice", "alice"); // -> initUserShard -> probe GET
+      // refreshLikesNow is private; drive it via the public update-notification
+      // path would debounce, so reach it through likePost is heavier. Instead
+      // issue a second user-shard load via loadState() once the shard key is set.
+      await flush();
+
+      // Exactly one GET in flight after kicking off the first flow.
+      expect(api.getCalls.length).toBe(1);
+
+      // Start a SECOND serialised GET (another load). It must NOT call api.get()
+      // yet — it's queued behind the first on getChain.
+      conn.loadState();
+      await flush();
+      expect(api.getCalls.length).toBe(1); // still only the first
+
+      // Settle the first GET (reject = not-found probe). Chain advances.
+      api.getCalls[0].reject(new Error("not found"));
+      await flush();
+      await flush();
+
+      // Now the second GET is allowed out.
+      expect(api.getCalls.length).toBe(2);
+    });
+
+    it("advances the chain even when a GET rejects (no wedge)", async () => {
+      const { conn, api } = makeConnection();
+
+      // Establish the user-shard key cleanly: resolve initUserShard's probe so
+      // it treats the shard as existing (no PUT/fetch), then it issues its own
+      // loadUserShard GET. Settle that too so the chain is idle and the key set.
+      conn.setUser(OWNER_VK, "Alice", "alice");
+      await flush();
+      expect(api.getCalls.length).toBe(1); // the probe
+      api.getCalls[0].resolve({} as GetResponse); // exists -> no PUT
+      await flush();
+      await flush();
+      expect(api.getCalls.length).toBe(2); // loadUserShard GET issued
+      api.getCalls[1].resolve({} as GetResponse);
+      await flush();
+      await flush();
+
+      // Now drive two serialised loadState() GETs. Reject the first: a wedged
+      // chain would block the second forever; the fix advances getChain on
+      // settle either way.
+      conn.loadState();
+      await flush();
+      expect(api.getCalls.length).toBe(3);
+      conn.loadState();
+      await flush();
+      expect(api.getCalls.length).toBe(3); // queued behind the (rejecting) #3
+
+      api.getCalls[2].reject(new Error("timeout"));
+      await flush();
+      await flush();
+      // The second load got out despite the rejection -> chain not wedged.
+      expect(api.getCalls.length).toBe(4);
+    });
+
+    it("each caller sees its own GET outcome (resolve), then chain continues", async () => {
+      const { conn, api } = makeConnection();
+      conn.setUser(OWNER_VK, "Alice", "alice");
+      await flush();
+      expect(api.getCalls.length).toBe(1);
+
+      conn.loadState();
+      await flush();
+      expect(api.getCalls.length).toBe(1);
+
+      // Resolve the first probe GET successfully -> userShardExists() true ->
+      // no PUT; chain advances and releases the queued load.
+      api.getCalls[0].resolve({} as GetResponse);
+      await flush();
+      await flush();
+      expect(api.getCalls.length).toBe(2);
+    });
+  });
+
+  describe("dropPendingLike — nonce matching", () => {
+    it("returns true only when a matching pending like exists, false otherwise", async () => {
+      const { conn, api } = makeConnection();
+
+      // Seed a pending like via likePost. likePost -> ensureThreadShard probe
+      // GET; resolve it so the shard is treated as existing, then signLike (mock)
+      // returns true and the pending like is recorded.
+      const likePromise = conn.likePost("post-1", true);
+      await flush();
+      // ensureThreadShard issued a probe GET; resolve it as existing.
+      expect(api.getCalls.length).toBe(1);
+      api.getCalls[0].resolve({} as GetResponse);
+      const ok = await likePromise;
+      expect(ok).toBe(true);
+
+      // We don't know the internal nonce, so test the false branch directly and
+      // then exercise the true branch via completeLike below.
+      expect(conn.dropPendingLike("nonce-that-does-not-exist")).toBe(false);
+    });
+  });
+
+  describe("optimistic like revert", () => {
+    it("completeLike refreshes (re-GETs) on update SUCCESS", async () => {
+      const { conn, api } = makeConnection();
+
+      // Drive completeLike for a known nonce. It folds the like into the thread
+      // shard via update(), then refreshLikesNow() issues a GET to read back the
+      // authoritative aggregate.
+      const before = api.getCalls.length;
+      const ok = await conn.completeLike({
+        nonce: "n1",
+        root_post_id: "root-success",
+        signer_pubkey: OWNER_VK,
+        seq: Date.now(),
+        liked: true,
+        signature: "sig",
+      });
+      // No matching pending like was registered, so completeLike short-circuits
+      // false BEFORE updating — register one first to reach the success path.
+      expect(ok).toBe(false);
+      expect(api.updateCalls.length).toBe(0);
+      expect(api.getCalls.length).toBe(before);
+    });
+
+    it("completeLike (matched nonce) updates then refreshes on SUCCESS", async () => {
+      const { conn, api } = makeConnection();
+
+      // Register a pending like through likePost, capturing its nonce.
+      const signLikeMock = (await import("./identity"))
+        .signLike as unknown as ReturnType<typeof vi.fn>;
+      const likePromise = conn.likePost("root-ok", true);
+      await flush();
+      api.getCalls[api.getCalls.length - 1].resolve({} as GetResponse); // probe exists
+      await likePromise;
+      // signLike(nonce, rootPostId, seq, liked) — first arg is the nonce.
+      const nonce = signLikeMock.mock.calls[0][0] as string;
+
+      const getsBefore = api.getCalls.length;
+      const ok = await conn.completeLike({
+        nonce,
+        root_post_id: "root-ok",
+        signer_pubkey: OWNER_VK,
+        seq: Date.now(),
+        liked: true,
+        signature: "sig",
+      });
+      expect(ok).toBe(true);
+      // Update sent, then a refresh GET issued.
+      expect(api.updateCalls.length).toBe(1);
+      expect(api.getCalls.length).toBe(getsBefore + 1);
+      // The matched nonce was consumed; dropping it again is a no-op.
+      expect(conn.dropPendingLike(nonce)).toBe(false);
+    });
+
+    it("completeLike refreshes on update FAILURE so the UI reconciles", async () => {
+      const { conn, api } = makeConnection();
+      api.updateError = new Error("update rejected");
+
+      const signLikeMock = (await import("./identity"))
+        .signLike as unknown as ReturnType<typeof vi.fn>;
+      const likePromise = conn.likePost("root-fail", true);
+      await flush();
+      api.getCalls[api.getCalls.length - 1].resolve({} as GetResponse);
+      await likePromise;
+      const nonce = signLikeMock.mock.calls[
+        signLikeMock.mock.calls.length - 1
+      ][0] as string;
+
+      const getsBefore = api.getCalls.length;
+      const ok = await conn.completeLike({
+        nonce,
+        root_post_id: "root-fail",
+        signer_pubkey: OWNER_VK,
+        seq: Date.now(),
+        liked: true,
+        signature: "sig",
+      });
+      // Update failed -> returns false, but STILL re-GETs to reconcile the
+      // optimistic toggle away (the H-fix: refresh on BOTH paths).
+      expect(ok).toBe(false);
+      expect(api.updateCalls.length).toBe(1);
+      expect(api.getCalls.length).toBe(getsBefore + 1);
+    });
+
+    it("dropPendingLike returns true for a real pending like, then false", async () => {
+      const { conn, api } = makeConnection();
+      const signLikeMock = (await import("./identity"))
+        .signLike as unknown as ReturnType<typeof vi.fn>;
+
+      const likePromise = conn.likePost("root-drop", true);
+      await flush();
+      api.getCalls[api.getCalls.length - 1].resolve({} as GetResponse);
+      await likePromise;
+      const nonce = signLikeMock.mock.calls[
+        signLikeMock.mock.calls.length - 1
+      ][0] as string;
+
+      expect(conn.dropPendingLike(nonce)).toBe(true); // matched -> dropped
+      expect(conn.dropPendingLike(nonce)).toBe(false); // already gone
+    });
+  });
+
+  describe("completePublish / dropPendingPost — nonce matching", () => {
+    async function seedDraft(conn: FreenetConnection) {
+      // publishPost needs a user shard + currentUser. setUser sets currentUser
+      // and kicks off initUserShard (which sets userShardKey synchronously after
+      // deriving — but it's async). Drive it and settle the probe so the shard
+      // key is in place.
+      const signPostMock = (await import("./identity"))
+        .signPost as unknown as ReturnType<typeof vi.fn>;
+      const ok = await conn.publishPost("hello world");
+      return { ok, signPostMock };
+    }
+
+    it("completePublish with an UNKNOWN nonce returns false, leaves drafts intact", async () => {
+      const { conn, api } = makeConnection();
+      conn.setUser(OWNER_VK, "Alice", "alice");
+      await flush();
+      // Resolve the user-shard probe so userShardKey/exists is settled.
+      if (api.getCalls.length) api.getCalls[0].resolve({} as GetResponse);
+      await flush();
+
+      const { ok, signPostMock } = await seedDraft(conn);
+      expect(ok).toBe(true);
+      const realNonce = signPostMock.mock.calls[
+        signPostMock.mock.calls.length - 1
+      ][0] as string;
+
+      // Unknown nonce -> no draft matched -> false, and no update sent.
+      const updatesBefore = api.updateCalls.length;
+      const res = await conn.completePublish({
+        nonce: "no-such-nonce",
+        post_id: "pid",
+        signature: "sig",
+        public_key: OWNER_VK,
+      });
+      expect(res).toBe(false);
+      expect(api.updateCalls.length).toBe(updatesBefore);
+
+      // The real draft is still there: completing it now succeeds and sends an
+      // update (proving the unknown-nonce call did NOT consume it).
+      const res2 = await conn.completePublish({
+        nonce: realNonce,
+        post_id: "pid",
+        signature: "sig",
+        public_key: OWNER_VK,
+      });
+      expect(res2).toBe(true);
+      expect(api.updateCalls.length).toBe(updatesBefore + 1);
+    });
+
+    it("dropPendingPost removes only the matching nonce", async () => {
+      const { conn, api } = makeConnection();
+      conn.setUser(OWNER_VK, "Alice", "alice");
+      await flush();
+      if (api.getCalls.length) api.getCalls[0].resolve({} as GetResponse);
+      await flush();
+
+      const signPostMock = (await import("./identity"))
+        .signPost as unknown as ReturnType<typeof vi.fn>;
+
+      // Two drafts queued.
+      await conn.publishPost("first");
+      await conn.publishPost("second");
+      const nonceA = signPostMock.mock.calls[0][0] as string;
+      const nonceB = signPostMock.mock.calls[1][0] as string;
+      expect(nonceA).not.toBe(nonceB);
+
+      // Drop only A. B must survive: completePublish(B) succeeds, A fails.
+      conn.dropPendingPost(nonceA);
+
+      const resA = await conn.completePublish({
+        nonce: nonceA,
+        post_id: "pa",
+        signature: "s",
+        public_key: OWNER_VK,
+      });
+      expect(resA).toBe(false); // A was dropped
+
+      const resB = await conn.completePublish({
+        nonce: nonceB,
+        post_id: "pb",
+        signature: "s",
+        public_key: OWNER_VK,
+      });
+      expect(resB).toBe(true); // B untouched
+    });
+  });
+
+  describe("handleGetResponse routing -> like aggregate", () => {
+    it("a thread-shard GET response emits onLikeUpdated with the correct count/likedByMe", async () => {
+      const { conn, api, callbacks } = makeConnection();
+
+      // ownerVkHex (used by emitLikeState for likedByMe) is only set when a real
+      // 3904-char VK is supplied via setUser. Set it, then settle the user-shard
+      // init GETs so the chain is idle.
+      conn.setUser(OWNER_VK, "Alice", "alice");
+      await flush();
+      api.getCalls[0].resolve({} as GetResponse); // probe -> exists
+      await flush();
+      await flush();
+      if (api.getCalls[1]) api.getCalls[1].resolve({} as GetResponse); // loadUserShard
+      await flush();
+      await flush();
+
+      // Like a post so the thread key + instance->root mapping is registered
+      // (handleGetResponse routes by instance id).
+      const rootId = "thread-root-1";
+      const likePromise = conn.likePost(rootId, true);
+      await flush();
+      const probe = api.getCalls[api.getCalls.length - 1];
+      probe.resolve({} as GetResponse);
+      await likePromise;
+
+      // Build a thread-shard GET response for that key with two likes, one of
+      // them by the owner, and feed it through the captured handler.
+      const likes = {
+        a: { signer_pubkey: OWNER_VK, seq: 1, liked: true, signature: "s" },
+        b: { signer_pubkey: "cd".repeat(1952), seq: 1, liked: true, signature: "s" },
+        c: { signer_pubkey: "ef".repeat(1952), seq: 2, liked: false, signature: "s" },
+      };
+      const stateBytes = Array.from(
+        new TextEncoder().encode(JSON.stringify({ likes })),
+      );
+      const key = probe.req.key; // same ContractKey the thread uses
+
+      callbacks.onLikeUpdated.mockClear();
+      api.handler.onContractGet({
+        key,
+        state: stateBytes,
+      } as unknown as GetResponse);
+
+      expect(callbacks.onLikeUpdated).toHaveBeenCalledTimes(1);
+      const emitted = callbacks.onLikeUpdated.mock.calls[0][0] as LikeState;
+      expect(emitted.postId).toBe(rootId);
+      expect(emitted.count).toBe(2); // two liked:true records
+      expect(emitted.likedByMe).toBe(true); // owner is among them
+    });
+  });
+});

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -161,16 +161,23 @@ export class FreenetConnection {
    * the owner VK changes (identity switch) so the new shard re-initialises. */
   private userShardInitOwner: string | null = null;
   /**
-   * Resolves once {@link startup} (migration loop + legacy load/subscribe) has
-   * finished. The stdlib resolves GET responses from a single FIFO queue with
-   * no request correlation, so issuing the shard's probe/load GETs while the
-   * migration loop is still awaiting its own GETs lets the two steal each
-   * other's responses (a shard NotFound could reject a migration GET, and a
-   * legacy response could resolve the shard probe → a spurious "exists" → the
-   * shard is never PUT). Serialise shard init behind this barrier.
+   * Serialises every `api.get()` so at most one GET is in flight at a time.
+   *
+   * The stdlib resolves GET promises from a single FIFO queue with NO request
+   * correlation: the Nth `GetResponse`/`NotFound` to arrive settles the Nth
+   * pending `get()` promise, regardless of which contract it was for. With
+   * multiple concurrent shard flows live (user-shard probe/load, per-thread
+   * probe/like-refresh) two in-flight GETs can have their responses swapped —
+   * a thread GET resolving the user-shard probe (→ feed never instantiates) or
+   * a like-refresh popping a thread probe (→ that thread never PUT, the like is
+   * silently lost). Routing-by-key in `handleGetResponse` fixes WHICH handler
+   * runs, but not WHICH awaited promise settles. The only robust fix without
+   * stdlib request-ids is to never have two GETs outstanding: each `api.get()`
+   * awaits the previous one's settle. (The prior `startupDone` barrier only
+   * covered startup-time traffic, which #33 removed — it serialised nothing
+   * against the real post-init concurrency.)
    */
-  private startupDone: Promise<void> = Promise.resolve();
-  private resolveStartupDone: () => void = () => {};
+  private getChain: Promise<unknown> = Promise.resolve();
   /**
    * Per-thread shard keys, lazily derived the first time a post is liked. Keyed
    * by root post id (the thread-shard parameter). A thread shard is parameterized
@@ -194,14 +201,6 @@ export class FreenetConnection {
     // __OFFLINE_MODE__ in index.ts (offline skips connect and renders mock
     // data), so connect() always opens the socket when called.
     this.callbacks.onStatusChange("connecting");
-
-    // Arm the startup barrier synchronously, before the socket opens — a
-    // delegate identity (→ setUser → initUserShard) can never beat startup() to
-    // assigning it, so shard init always awaits the real barrier, not the
-    // default-resolved field.
-    this.startupDone = new Promise((resolve) => {
-      this.resolveStartupDone = resolve;
-    });
 
     try {
       const wsUrl = new URL(`ws://${location.host}/v1/contract/command`);
@@ -230,7 +229,6 @@ export class FreenetConnection {
         onOpen: () => {
           console.log("[freenet] Connected to Freenet node");
           this.callbacks.onStatusChange("connected");
-          void this.startup();
         },
       };
       // Pass empty string as authToken to skip cookie reading (sandbox blocks it)
@@ -242,13 +240,27 @@ export class FreenetConnection {
   }
 
   /**
-   * Resolve the startup barrier. There is no global contract to load/subscribe
-   * here — the feed comes from the owner's user shard, instantiated by
-   * `initUserShard` once the delegate reports the identity (setUser). This only
-   * unblocks any shard init that arrived mid-startup.
+   * Issue a GET serialised behind {@link getChain}, so it is the only GET in
+   * flight when its response arrives — defeating the stdlib's uncorrelated FIFO
+   * response queue. The returned promise resolves/rejects exactly with THIS
+   * GET's response (since no other GET overlaps it), and the chain advances on
+   * settle (success or failure) so one rejected/timed-out GET cannot wedge the
+   * rest. A per-GET timeout bounds head-of-line blocking.
    */
-  private async startup(): Promise<void> {
-    this.resolveStartupDone();
+  private serializedGet(req: GetRequest, ms = 8000): Promise<GetResponse> {
+    if (!this.api) return Promise.reject(new Error("no api"));
+    const api = this.api;
+    const run = this.getChain.then(
+      () => this.withTimeout(api.get(req), ms),
+      () => this.withTimeout(api.get(req), ms),
+    );
+    // Advance the chain on settle without propagating this GET's result/error
+    // to the next link (each caller still sees its own outcome via `run`).
+    this.getChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   private withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
@@ -271,8 +283,7 @@ export class FreenetConnection {
     // The feed is sourced solely from the owner's user shard. index.ts refreshes
     // via loadState after a publish, so this targets the same key writes go to.
     if (!this.api || !this.userShardKey) return;
-    const req = new GetRequest(this.userShardKey, true);
-    this.api.get(req).catch((e) =>
+    this.serializedGet(new GetRequest(this.userShardKey, true)).catch((e) =>
       console.error("[freenet] Get request failed:", e)
     );
   }
@@ -338,7 +349,7 @@ export class FreenetConnection {
       // User-shard deltas are the externally-tagged `ShardDelta` enum
       // (`{"Posts":[…]}` / `{"Op":…}`). Op deltas (profile/follow) carry no feed
       // posts — ignore them here.
-      const parsed = JSON.parse(deltaJson.replace("\x00", "")) as {
+      const parsed = JSON.parse(deltaJson.replace(/\x00/g, "")) as {
         Posts?: ContractPost[];
         Op?: unknown;
       };
@@ -380,14 +391,10 @@ export class FreenetConnection {
     }
     this.userShardInitOwner = owner;
     try {
-      // Wait for startup() to resolve the barrier before issuing any shard GET.
-      // (The barrier is armed in connect() before the socket opens; it exists so
-      // that any future startup-time contract traffic can't race shard init on
-      // the stdlib's uncorrelated GET response queue — see startupDone.)
-      await this.startupDone;
-      // A newer identity may have arrived while we awaited — bail if so.
-      if (this.ownerVkHex !== owner) return;
-
+      // GET-response ordering is handled by serializedGet (one GET in flight at
+      // a time), so shard init no longer needs a startup barrier — it can issue
+      // its probe/load GETs concurrently with any other flow and the chain
+      // keeps each GET's response matched to its own promise.
       const vkBytes = hexToBytes(owner);
       this.userShardKey = deriveShardContractKey(codeHash, vkBytes);
       this.userShardInstanceId = this.userShardKey.encode();
@@ -426,10 +433,7 @@ export class FreenetConnection {
   private async userShardExists(): Promise<boolean> {
     if (!this.api || !this.userShardKey) return false;
     try {
-      await this.withTimeout(
-        this.api.get(new GetRequest(this.userShardKey, false)),
-        8000,
-      );
+      await this.serializedGet(new GetRequest(this.userShardKey, false));
       return true;
     } catch {
       return false;
@@ -490,9 +494,9 @@ export class FreenetConnection {
 
   private loadUserShard(): void {
     if (!this.api || !this.userShardKey) return;
-    this.api
-      .get(new GetRequest(this.userShardKey, true))
-      .catch((e) => console.error("[user-shard] get failed:", e));
+    this.serializedGet(new GetRequest(this.userShardKey, true)).catch((e) =>
+      console.error("[user-shard] get failed:", e),
+    );
   }
 
   private subscribeUserShard(): void {
@@ -535,14 +539,20 @@ export class FreenetConnection {
     return new Uint8Array(await resp.arrayBuffer());
   }
 
-  /** PUT the parameterized thread-shard container if the node lacks it. */
+  /**
+   * Ensure the post's thread shard is instantiated on the node: GET-probe, and
+   * PUT the parameterized container if absent. Awaits the PUT before returning,
+   * so the caller knows the shard exists before sending a like UpdateRequest
+   * (an update to a never-instantiated contract is silently dropped by the
+   * node — see M-3). Throws if the PUT itself fails.
+   */
   private async ensureThreadShard(
     key: ContractKey,
     rootPostId: string,
   ): Promise<void> {
-    if (!this.api) return;
+    if (!this.api) throw new Error("no api");
     try {
-      await this.withTimeout(this.api.get(new GetRequest(key, false)), 8000);
+      await this.serializedGet(new GetRequest(key, false));
       return; // already instantiated
     } catch {
       // not found / timeout → PUT below (a spurious re-PUT merges to a no-op)
@@ -644,6 +654,9 @@ export class FreenetConnection {
       return true;
     } catch (e) {
       console.error("[thread] failed to send like:", e);
+      // The update did not land — re-GET the authoritative aggregate so the
+      // optimistic toggle is reconciled away (onLikeUpdated reverts the UI).
+      this.refreshLikesNow(signed.root_post_id);
       return false;
     }
   }
@@ -653,9 +666,9 @@ export class FreenetConnection {
     if (!this.api) return;
     const key = this.threadKeyFor(rootPostId);
     if (!key) return;
-    this.api
-      .get(new GetRequest(key, true))
-      .catch((e) => console.error("[thread] like refresh GET failed:", e));
+    this.serializedGet(new GetRequest(key, true)).catch((e) =>
+      console.error("[thread] like refresh GET failed:", e),
+    );
   }
 
   /**

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -242,25 +242,38 @@ export class FreenetConnection {
   /**
    * Issue a GET serialised behind {@link getChain}, so it is the only GET in
    * flight when its response arrives — defeating the stdlib's uncorrelated FIFO
-   * response queue. The returned promise resolves/rejects exactly with THIS
-   * GET's response (since no other GET overlaps it), and the chain advances on
-   * settle (success or failure) so one rejected/timed-out GET cannot wedge the
-   * rest. A per-GET timeout bounds head-of-line blocking.
+   * response queue.
+   *
+   * CRITICAL: the chain must advance on the UNDERLYING `api.get()` settle, not
+   * on a shorter app-level timeout. The stdlib keeps the GET registered in its
+   * `pendingGets` FIFO until either a real GetResponse/NotFound or its OWN
+   * `REQUEST_TIMEOUT_MS` (30 s) fires. If we advanced the chain on a 8 s app
+   * timeout we would issue the next `api.get()` while the timed-out one is still
+   * in `pendingGets` → two entries → a late response pops the wrong promise
+   * (the very misroute this exists to prevent). So `getChain` chains on the raw
+   * stdlib promise `p`; the chain can only advance once the stdlib entry is
+   * truly gone, and a genuinely hung GET still drains via the stdlib's 30 s
+   * reject. The caller's optional `ms` is a SOFT view (resolve/reject the caller
+   * early) that does NOT release the next GET.
    */
   private serializedGet(req: GetRequest, ms = 8000): Promise<GetResponse> {
     if (!this.api) return Promise.reject(new Error("no api"));
     const api = this.api;
-    const run = this.getChain.then(
-      () => this.withTimeout(api.get(req), ms),
-      () => this.withTimeout(api.get(req), ms),
+    // The raw stdlib GET — its settle is what owns a `pendingGets` slot.
+    const p = this.getChain.then(
+      () => api.get(req),
+      () => api.get(req),
     );
-    // Advance the chain on settle without propagating this GET's result/error
-    // to the next link (each caller still sees its own outcome via `run`).
-    this.getChain = run.then(
+    // Advance the chain ONLY when the stdlib GET itself settles (entry drained),
+    // never on the soft app timeout below.
+    this.getChain = p.then(
       () => undefined,
       () => undefined,
     );
-    return run;
+    // Caller sees a soft 8 s bound; the underlying GET keeps its stdlib slot
+    // until it really settles, so the chain stays correct even if the caller
+    // gave up. (`ms === 0` disables the soft timeout — caller awaits the raw GET.)
+    return ms > 0 ? this.withTimeout(p, ms) : p;
   }
 
   private withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {

--- a/web/src/shard-key.test.ts
+++ b/web/src/shard-key.test.ts
@@ -77,6 +77,45 @@ describe("shard-key derivation", () => {
     );
   });
 
+  // Inbox shards are parameterized by the OWNER VK bytes — the SAME raw-VK-bytes
+  // param encoding as the user shard (NOT the user-shard's utf8-id encoding the
+  // thread shard uses). The risk this pins: a future change accidentally feeds
+  // the inbox a hex STRING (3904 ASCII bytes) instead of the raw 1952 VK bytes,
+  // silently addressing an empty contract — exactly the bug the thread-shard
+  // vector guards against in the opposite direction.
+  //
+  // SELF-DERIVED, NOT NODE GROUND TRUTH. Unlike the user and thread vectors
+  // above (pinned from `fdev get-contract-id` against a built .wasm), the inbox
+  // shard is currently UNWIRED in this worktree: there is no built inbox .wasm,
+  // no build/inbox_shard_code_hash, and no __INBOX_SHARD_CODE_HASH__ injected by
+  // vite. So no real node-derived instance id exists to pin against yet. This
+  // vector instead cross-checks the raw-VK-bytes ENCODING through the exact same
+  // deriveInstanceId path the user shard uses, with a PLACEHOLDER code hash.
+  //
+  // TODO(inbox-wire): once the inbox shard is built (Makefile.toml
+  // `build-inbox-shard` writes build/inbox_shard_code_hash, and vite injects
+  // __INBOX_SHARD_CODE_HASH__), replace INBOX_CODE_HASH_PLACEHOLDER with the real
+  // code hash and re-pin the expected base58 against:
+  //   $ fdev get-contract-id \
+  //       --code …/freenet_microblogging_inbox_shard.wasm \
+  //       --parameters <1952 raw VK bytes>
+  // so this becomes a real node ground-truth vector like the others.
+  it("derives inbox-shard key from raw VK bytes (self-derived, not node truth)", () => {
+    // Reuse the verified user-shard code hash purely as a stand-in: it proves the
+    // raw-VK-bytes derivation path is exercised, while the value above is the only
+    // node-verified one. The assertion is self-consistent (JS derivation pinned
+    // against itself), not a node cross-check — see the TODO above.
+    const INBOX_CODE_HASH_PLACEHOLDER =
+      "7iSNUfGW4WiJMuQ3ryxsD7KNPDAi31MpNoQ2nhPJRDXm";
+    // Fixed deterministic owner VK: 1952 raw bytes (NOT the 3904-char hex string).
+    const ownerVk = hexToBytes("ab".repeat(1952));
+    expect(ownerVk.length).toBe(1952); // raw VK bytes, NOT 3904 hex chars
+    // Pinned self-derived output: blake3(code_hash_bytes || raw_vk_bytes), base58.
+    expect(deriveInstanceId(INBOX_CODE_HASH_PLACEHOLDER, ownerVk).base58).toBe(
+      "76Afq1mAEsiEQRQxNckj9PuAgc3Z9e2uPfXrdCz6JYNB",
+    );
+  });
+
   it("rejects a code hash that does not decode to 32 bytes", () => {
     expect(() => deriveInstanceId("abc", new Uint8Array(0))).toThrow(
       /32 bytes/,


### PR DESCRIPTION
## What

Whole-system review of the merged ADR-0001 shard stack (PRs #24–#33) — reading all three shards + the identity delegate + the web client *together*, rather than one PR diff at a time — surfaced fixes the per-slice reviews structurally could not see.

## Code fixes

- **H-1 (regression introduced by the #33 teardown).** The stdlib resolves GET promises off a single uncorrelated FIFO queue (Nth response settles the Nth pending `get()`, regardless of contract). The slice-1 `startupDone` barrier only serialized *startup-time* traffic, which the teardown removed — so post-cutover, with multiple shard flows live at once (user-shard probe/load, per-thread probe/like-refresh), two in-flight GETs could swap responses: a thread GET resolving the user-shard probe (feed never instantiates) or a like-refresh popping a thread probe (that thread never PUT → the like silently lost). Replaced the vestigial barrier with `serializedGet`: every `api.get()` chains behind the previous one's settle, so at most one GET is outstanding and each response matches its own promise.
- **M-3.** `ensureThreadShard` now awaits its PUT before the caller sends the like UPDATE (an UPDATE to a never-instantiated contract is silently dropped by the node), and `completeLike` re-GETs the authoritative aggregate on UPDATE *failure* too, so the optimistic toggle is always reconciled rather than left stuck.
- **L-1.** Strip all NUL padding from user-shard deltas, not just the first.
- **H-3** (fabricated-engagement / dangling threads): accepted + already mitigated client-side (`onLikeUpdated` ignores aggregates for posts not in the feed; post ids are content-addressed). Documented the residual trust model.

## Tests

- **Identity delegate: first unit tests** (was zero — the single largest hole). Export→import seed round-trip, and `SignPost`/`SignLike` outputs verify under the same `common` code the contracts run (thread-context binding, `vk_hex == owner param`). Extracted two pure signing helpers so tests exercise the real assembly code; `process()` end-to-end stays node-tier-only (WASM-only secret store).
- **`StateAndDelta` update arm** exercised in all three contracts (was untested).
- **Web client** `freenet-api.test.ts`: pins the `serializedGet` single-in-flight property (the H-1 anti-misroute guarantee), optimistic-like revert, nonce matching.
- **Golden signing-payload byte vectors** in `common` (tripwire vs consistent encoding drift that passes injectivity tests); **inbox-shard key derivation vector** in the web suite.

## Docs / tracking

- Finished the #33 teardown doc sync: AGENTS.md migration section (pointed at deleted `web/src/migrations/`) + delta-format line; README Ed25519→ML-DSA-65, shard roadmap, `SignLike` + deferred reply/inbox wiring.
- Closed obsolete issue #23 (migration runtime deleted in #33).
- Opened #34 for the WASM-in-node e2e tier — the load-bearing `GET-rejects-on-uninstantiated` assumption is still unverified against a live node.

## Gates
`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (124 Rust tests), `vitest` (23 web tests), `tsc --noEmit`, and `wasm32` release build of all contracts + delegate — all green locally.

Refs #33, #34. Closes #23 (closed directly).