### PR TITLE
fix: revert optimistic like toggle on completeLike failure

### DIFF
--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -224,6 +224,15 @@ const connection = new FreenetConnection({
             liked: signedLike.liked,
             signature: signedLike.signature,
           })
+          .then((ok) => {
+            // completeLike already fires a best-effort re-GET to reconcile, but
+            // that depends on a second round-trip succeeding (and the network
+            // condition that failed the UPDATE likely fails the GET too). On a
+            // hard false, revert the optimistic toggle from localPosts directly
+            // so the like never sticks on the card. Mirrors the likePost(false)
+            // and dropPendingLike paths.
+            if (!ok) refreshFeed();
+          })
           .catch((e) => console.error("[delegate] completeLike failed:", e));
         return;
       }


### PR DESCRIPTION
Follow-up to PR #35 holistic review (MINOR-1).

## Problem

`completeLike` returns `false` when the thread-shard UPDATE throws (`freenet-api.ts:673`), but the caller in `index.ts` ignored the boolean — only `.catch()`ing the never-rejecting promise. The sole revert path on UPDATE failure was the fire-and-forget `refreshLikesNow()` re-GET inside `completeLike`.

That re-GET depends on a **second** network round-trip succeeding. The network condition that failed the UPDATE will usually fail the GET too → the optimistic like stays lit on the card with no authoritative state to reconcile it away.

## Fix

Drive the UI revert directly from `completeLike(false)` by re-rendering from `localPosts` (the last authoritative state), mirroring the existing `likePost(false) → refreshFeed()` and `dropPendingLike → refreshFeed()` paths. The re-GET stays as the authoritative reconcile when the network recovers; this is the local fallback when it does not.

## Test

- `npx tsc --noEmit` clean
- `npx vitest run` — 24 pass

Web-only change (`web/src/index.ts`); no Rust touched.