### PR TITLE
feat(facade): per-release pointer flip + Linux byte gate (#45 phase 3+4)

### DIFF
--- a/.github/workflows/check-contract-wasm.yml
+++ b/.github/workflows/check-contract-wasm.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "web/**"
       - "contracts/**"
+      - "scripts/check-facade-byte-equal.sh"
+      - "scripts/build-facade-snapshot-linux.sh"
       - "delegates/**"
       - "tools/web-container-sign/**"
       - "published-contract/**"
@@ -18,6 +20,8 @@ on:
     paths:
       - "web/**"
       - "contracts/**"
+      - "scripts/check-facade-byte-equal.sh"
+      - "scripts/build-facade-snapshot-linux.sh"
       - "delegates/**"
       - "tools/web-container-sign/**"
       - "published-contract/**"
@@ -83,4 +87,23 @@ jobs:
         with:
           name: published-contract-rebuilt
           path: published-contract/
+          retention-days: 14
+
+      # Issue #45 Phase 4: the facade contract id is the stable bookmarkable
+      # URL (hash of facade.wasm + facade.parameters). Guard facade.wasm
+      # byte-equality so a dep/rustc change can't silently rotate the id and
+      # orphan every bookmark. No-ops (warn + pass) until the facade snapshot
+      # is bootstrapped — see RELEASING.md §"One-time facade publish".
+      - name: Verify facade wasm byte-equality (issue #45)
+        id: facade-verify
+        run: bash scripts/check-facade-byte-equal.sh
+
+      # On drift, upload the canonical CI-built facade.wasm so an operator can
+      # recompute facade-id.txt and commit a deliberate snapshot refresh.
+      - name: Upload rebuilt facade.wasm on drift
+        if: failure() && steps.facade-verify.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: facade-wasm-rebuilt-${{ github.sha }}
+          path: contracts/facade/target/wasm32-unknown-unknown/release/freenet_microblogging_facade.wasm
           retention-days: 14

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,6 +77,143 @@ It then prompts 3 times before destructive steps:
 2. Before committing `published-contract/`
 3. Before pushing to `origin`
 
+## Facade contract — stable bookmarkable URL (issue #45)
+
+The web-container contract id rotates every release (its wasm + signature
+change), so any URL a user bookmarked points at the *previous* release and
+goes stale. The **facade** is a second contract whose id stays byte-stable
+forever; its signed state points at the *current* release's web-container
+id. Users bookmark the facade URL; each release flips the pointer.
+
+```
+user bookmark ──► facade contract (STABLE id) ──► current webapp (rotating id)
+                  (loader HTML, postMessage nav)    (the actual UI)
+```
+
+The facade crates live **outside** the Cargo workspace
+(`contracts/facade`, `contracts/facade-types`) with their own pinned
+`Cargo.lock`, so dependency churn in the main workspace can't rotate the
+facade wasm bytes — which would rotate its id and break every bookmark.
+
+### One-time facade publish (per network)
+
+Before the per-release flip can run, the facade must be published once and
+its id committed. Do this once per network (sandbox, then production):
+
+```bash
+# 1. Build the facade + sign initial state pointing at the current webapp,
+#    then snapshot wasm/parameters/id into published-contract/.
+cargo make update-published-facade
+git add published-contract/facade.wasm published-contract/facade.parameters \
+        published-contract/facade-id.txt
+git commit -m "chore(facade): commit production facade snapshot"
+
+# 2. PUT the facade onto the network (ONE-TIME — never PUT again; later
+#    releases UPDATE the pointer, they don't re-publish the contract).
+cargo make publish-facade-test    # local sandbox
+# cargo make publish-facade       # live network (drops --port, real key)
+```
+
+`published-contract/facade-id.txt` is the stable, bookmarkable id. Once it
+is committed, `scripts/release.sh` performs the per-release flip
+automatically.
+
+**Canonical wasm bytes (linux/amd64).** `facade.wasm` must be byte-identical
+to what CI rebuilds, or the Phase 4 gate
+(`scripts/check-facade-byte-equal.sh`) fails. The facade builds
+deterministically *on a given host* but macOS/arm64 and linux/amd64 emit
+different codegen for the same source. The committed snapshot is canonical on
+**linux/amd64 with the pinned rustc** (what CI runs). On a Linux host,
+regenerate with `scripts/build-facade-snapshot-linux.sh`. On macOS, use the CI
+bootstrap path: commit your local bytes, let `check-contract-wasm.yml` fail
+byte-equality and upload the `facade-wasm-rebuilt-<sha>` artifact, download it,
+replace `published-contract/facade.wasm`, recompute `facade-id.txt` via
+`fdev get-contract-id`, and commit. (Same workflow we used for the
+web-container snapshot.)
+
+`facade.parameters` is the 32-byte production verifying key (the publisher
+identity); it is **not** rebuilt by CI — only `facade.wasm` is compared. The
+prod parameters + id are minted once, at the first `cargo make publish-facade`
+with the production key, and stay fixed forever after.
+
+### Per-release pointer flip (automatic)
+
+After the webapp publish and before the commit, `scripts/release.sh` (when
+`published-contract/facade-id.txt` exists):
+
+1. Re-renders the loader with the new `current_app_id` baked in
+   (`FACADE_CURRENT_APP_ID=$NEW_ID cargo make build-facade-loader`).
+2. Signs a fresh facade state with the production key, version
+   `WEBAPP_VERSION` (same monotonic packed semver the webapp uses).
+3. Prompts, then UPDATEs the facade:
+   `fdev execute update --as-state <FACADE_ID> target/facade/facade.state`.
+
+If the facade id is not yet committed, the script warns and skips the flip;
+the rest of the release still completes.
+
+**`--as-state` is mandatory.** The facade `update_state` only matches
+`UpdateData::State`; without the flag `fdev` sends `UpdateData::Delta` and
+the contract rejects it as `InvalidUpdate`, so the pointer silently never
+moves. `release.sh` preflight asserts the installed `fdev` supports it
+(only when the facade is in play).
+
+### Verifying the pointer flip
+
+```bash
+NEW_APP_ID=$(cat published-contract/contract-id.txt)
+FACADE_ID=$(cat published-contract/facade-id.txt)
+
+# Facade serves the loader, which bakes in the new app id.
+curl -s "http://127.0.0.1:7509/v1/contract/web/${FACADE_ID}/?__sandbox=1" \
+  | grep -F "${NEW_APP_ID}"          # expect the new id in CURRENT_APP_ID
+
+# New webapp itself serves.
+curl -sI "http://127.0.0.1:7509/v1/contract/web/${NEW_APP_ID}/" | head -1   # 200 OK
+
+# Browser smoke: open the facade URL — the loader postMessages the gateway
+# shell, which navigates to the new app.
+echo "open http://127.0.0.1:7509/v1/contract/web/${FACADE_ID}/"
+```
+
+### Manual flip (if release.sh aborts post-publish)
+
+If the script aborts after the webapp publish (e.g. `fdev publish` returns a
+client timeout though the server-side publish landed), the webapp is live
+but the pointer is stale. Resume:
+
+```bash
+NEW_APP_ID=$(cat published-contract/contract-id.txt)
+curl -sI "http://127.0.0.1:7509/v1/contract/web/${NEW_APP_ID}/" | head -1   # confirm 200
+
+FACADE_CURRENT_APP_ID="$NEW_APP_ID" cargo make sign-facade-state
+fdev execute update --as-state \
+    "$(cat published-contract/facade-id.txt)" \
+    target/facade/facade.state
+# then finish the commit/tag/push release.sh would have done.
+```
+
+### Loader template
+
+The loader is a static HTML+JS shell (`contracts/facade-loader/src/index.html.tmpl`)
+the facade serves; it bakes the current app id via the `__CURRENT_APP_ID__`
+placeholder and hands off to the new webapp through the gateway shell:
+
+```js
+window.parent.postMessage({ __freenet_shell__: true, type: 'navigate', href: target }, '*');
+```
+
+postMessage (not `location.replace`) because the gateway wraps each contract
+in a shell with `X-Frame-Options: DENY` inside a sandboxed iframe — a
+same-window `location.replace` would try to load the new contract's shell
+*inside* our iframe and the browser blocks it. Standalone (`?__sandbox=1` or
+no parent frame), it falls back to `location.replace`. Always edit the
+`.tmpl`, never the rendered `dist/index.html` (overwritten every build).
+
+The `published-contract/facade.{wasm,parameters}` + `facade-id.txt` snapshot
+is the source of truth for the stable id. A Linux byte-equality CI gate
+guards it (issue #45 Phase 4); if it drifts, the facade Cargo.lock or
+dependencies changed and the id would rotate — investigate before committing.
+
 ## Recovery
 
 If `release.sh` fails or you abort partway:

--- a/scripts/build-facade-snapshot-linux.sh
+++ b/scripts/build-facade-snapshot-linux.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Issue #45 (Phase 4). Rebuild published-contract/facade.{wasm,id.txt} from
+# source. ONLY canonical on native linux/amd64 hosts — bytes produced under
+# qemu emulation (Docker on macOS / arm64) drift slightly even with identical
+# rustc + source, so emulated rebuilds WILL NOT match the CI byte-equality
+# gate (scripts/check-facade-byte-equal.sh).
+#
+# Use this when:
+#   • Bumping rustc in rust-toolchain.toml.
+#   • Bumping a `=x.y.z` pin under contracts/facade/Cargo.toml or
+#     contracts/facade-types/Cargo.toml.
+#   • Editing facade source.
+#
+# On non-Linux/amd64 hosts: do NOT use this. Rely on the CI bootstrap path:
+#   1. Push the change with whatever facade.wasm bytes you have locally.
+#   2. check-contract-wasm.yml fails byte-equality and uploads the canonical
+#      CI-built wasm as artifact `facade-wasm-rebuilt-<sha>`.
+#   3. Download it, replace published-contract/facade.wasm, recompute
+#      facade-id.txt via `fdev get-contract-id`, commit, push.
+#   4. CI passes.
+#
+# This script reuses the existing facade.parameters (the 32-byte production
+# verifying key — the publisher identity, orthogonal to the build). It does
+# NOT mint parameters; a first-ever bootstrap mints them via
+# `cargo make publish-facade` with the production key (see RELEASING.md).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Read the pinned channel from rust-toolchain.toml so a rebuild is only
+# attempted when the toolchain is actually pinned (an unpinned "stable" would
+# make the snapshot non-reproducible the moment the channel advances).
+PINNED_RUSTC=$(awk -F'"' '/^channel/ {print $2; exit}' rust-toolchain.toml 2>/dev/null || echo "")
+if [ -z "$PINNED_RUSTC" ] || [ "$PINNED_RUSTC" = "stable" ]; then
+    echo "warn: rust-toolchain.toml has no explicit version pin (channel=${PINNED_RUSTC:-unset})." >&2
+    echo "      facade.wasm bytes are rustc-sensitive; an unpinned channel means the" >&2
+    echo "      snapshot will silently drift when stable advances. Pin an exact version" >&2
+    echo "      (e.g. 1.95.0) for a durable snapshot. Continuing with the active toolchain." >&2
+fi
+
+HOST_OS=$(uname -s)
+HOST_ARCH=$(uname -m)
+if [ "$HOST_OS" != "Linux" ] || [ "$HOST_ARCH" != "x86_64" ]; then
+    echo "error: this host is $HOST_OS/$HOST_ARCH; canonical snapshot bytes can only" >&2
+    echo "       be produced on native linux/amd64 (qemu emulation drifts vs CI)." >&2
+    echo "       Use the CI bootstrap path documented at the top of this script." >&2
+    exit 1
+fi
+
+WASM_OUT="$ROOT/contracts/facade/target/wasm32-unknown-unknown/release/freenet_microblogging_facade.wasm"
+
+echo "→ building facade natively (linux/amd64, rustc ${PINNED_RUSTC:-active})"
+(
+    cd "$ROOT/contracts/facade"
+    cargo build --release --target wasm32-unknown-unknown \
+        --no-default-features --features freenet-main-contract
+)
+[ -f "$WASM_OUT" ] || { echo "error: build succeeded but $WASM_OUT does not exist" >&2; exit 1; }
+
+PARAMS="$ROOT/published-contract/facade.parameters"
+if [ ! -f "$PARAMS" ]; then
+    echo "error: $PARAMS not found." >&2
+    echo "       For a first-ever bootstrap, publish the facade once with the" >&2
+    echo "       production key (RELEASING.md §\"One-time facade publish\") to mint" >&2
+    echo "       parameters, then re-run this to overwrite wasm with canonical bytes." >&2
+    exit 1
+fi
+
+cp "$WASM_OUT" "$ROOT/published-contract/facade.wasm"
+
+NEW_ID=$(CARGO_TARGET_DIR="$ROOT/target" fdev get-contract-id \
+    --code "$ROOT/published-contract/facade.wasm" \
+    --parameters "$PARAMS")
+[ -n "$NEW_ID" ] || { echo "error: fdev get-contract-id returned empty id" >&2; exit 1; }
+printf '%s\n' "$NEW_ID" > "$ROOT/published-contract/facade-id.txt"
+
+echo
+echo "✓ facade snapshot regenerated:"
+echo "    facade-id.txt    = $NEW_ID"
+echo "    facade.wasm      = $(wc -c < "$ROOT/published-contract/facade.wasm") bytes"
+echo "    facade.parameters= $(wc -c < "$PARAMS") bytes (unchanged — publisher key)"
+echo
+echo "Commit the published-contract/ diff alongside the change that rotated the"
+echo "bytes. The CI byte-equality gate fails until both land in the same PR."
+echo "If facade-id.txt changed, every bookmarked URL just broke — make sure that"
+echo "was intentional and announce the migration."

--- a/scripts/check-facade-byte-equal.sh
+++ b/scripts/check-facade-byte-equal.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Issue #45 (Phase 4).
+#
+# The facade contract's reason to exist is a STABLE contract id across
+# releases — that id is the bookmarkable URL users keep. The id is
+# hash(facade.wasm, facade.parameters); facade.wasm must stay byte-identical
+# release-to-release. This script rebuilds the facade wasm from source and
+# compares it against the committed published-contract/facade.wasm.
+#
+# A drift here means a dependency or rustc change leaked into facade.wasm
+# (e.g. a freenet-stdlib / ed25519-dalek / byteorder pin bump under
+# contracts/facade/Cargo.toml, or a rust-toolchain.toml bump). That rotates
+# the facade contract id and breaks every bookmarked URL. Either fix the
+# regression OR consciously accept the rotation, regenerate the committed
+# snapshot via scripts/build-facade-snapshot-linux.sh, and bump the docs.
+#
+# Note: this checks only facade.wasm. facade.parameters is the publisher's
+# 32-byte verifying key (the production identity), orthogonal to the build —
+# it is not produced here and not compared.
+#
+# Snapshot canonicalization: the committed bytes are produced on linux/amd64
+# with the rustc pinned in rust-toolchain.toml. CI runs on linux/amd64 with
+# the same pin, so the rebuild matches. Other host arch/OS combos (e.g.
+# macOS arm64 dev machines) produce different wasm bytes — same source,
+# different codegen — and would trigger a spurious failure. Detect
+# non-canonical hosts and skip with a warning so local devs aren't blocked.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Issue #45: facade lives in its own workspace at contracts/facade/ with a
+# separate Cargo.lock. Build artifacts go under contracts/facade/target/.
+WASM_OUT="$ROOT/contracts/facade/target/wasm32-unknown-unknown/release/freenet_microblogging_facade.wasm"
+COMMITTED="$ROOT/published-contract/facade.wasm"
+
+if [ ! -f "$COMMITTED" ]; then
+    echo "warn: $COMMITTED missing — facade not yet bootstrapped on any network."
+    echo "      The one-time publish (RELEASING.md §\"One-time facade publish\")"
+    echo "      commits the snapshot; until then this gate is a no-op. Skipping."
+    exit 0
+fi
+
+# Snapshot canonicalization. The committed bytes only match rebuilds on the
+# same canonical host the snapshot was produced on: linux/amd64 with the
+# pinned rustc. Skip with a warning otherwise.
+HOST_OS=$(uname -s)
+HOST_ARCH=$(uname -m)
+if [ "$HOST_OS" != "Linux" ] || [ "$HOST_ARCH" != "x86_64" ]; then
+    echo "warn: facade byte-equality check is canonical only on linux/amd64."
+    echo "      This host is $HOST_OS/$HOST_ARCH — skipping rebuild + compare."
+    echo "      To rebuild the snapshot deliberately, run:"
+    echo "        scripts/build-facade-snapshot-linux.sh"
+    exit 0
+fi
+
+# Build with the facade's own manifest + lockfile (issue #45). The release
+# pipeline builds with --no-default-features --features freenet-main-contract
+# (see Makefile.toml [tasks.build-facade]); match it so the bytes line up.
+(
+    cd "$ROOT/contracts/facade"
+    cargo build --release --target wasm32-unknown-unknown \
+        --no-default-features --features freenet-main-contract
+)
+
+if ! cmp -s "$WASM_OUT" "$COMMITTED"; then
+    echo "FAIL: facade wasm drift detected." >&2
+    echo "  built:     $WASM_OUT ($(wc -c < "$WASM_OUT") bytes, $(shasum -a 256 "$WASM_OUT" | cut -d' ' -f1))" >&2
+    echo "  committed: $COMMITTED ($(wc -c < "$COMMITTED") bytes, $(shasum -a 256 "$COMMITTED" | cut -d' ' -f1))" >&2
+    echo "" >&2
+    echo "If this drift is intentional (a deliberate facade upgrade), regenerate" >&2
+    echo "the committed snapshot on linux/amd64:" >&2
+    echo "  scripts/build-facade-snapshot-linux.sh" >&2
+    echo "  git add published-contract/facade.wasm published-contract/facade-id.txt" >&2
+    echo "Then update RELEASING.md to record the new facade id. NOTE: rotating the" >&2
+    echo "facade id breaks every bookmarked URL — do this only deliberately." >&2
+    exit 1
+fi
+
+echo "ok: facade wasm matches committed snapshot ($(wc -c < "$COMMITTED") bytes)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -92,6 +92,18 @@ for cmd in fdev cargo-make gh; do
     command -v "$cmd" >/dev/null 2>&1 || die "$cmd not on PATH"
 done
 
+# fdev must support --as-state for the facade pointer flip. Older builds
+# silently wrap the state file as UpdateData::Delta; the facade contract's
+# update_state only matches UpdateData::State and returns InvalidUpdate, so
+# the pointer never moves and the stable URL serves a stale app. Only enforced
+# when the facade has been published (facade-id.txt committed).
+if [ -f published-contract/facade-id.txt ]; then
+    if ! fdev execute update --help 2>&1 | grep -q -- '--as-state'; then
+        die "fdev does not support \`--as-state\` (required for facade UPDATE).
+Build a newer fdev: cargo install --path /path/to/freenet-core/crates/fdev"
+    fi
+fi
+
 if ! command -v gtar >/dev/null 2>&1 && ! tar --version 2>/dev/null | grep -qi 'gnu tar'; then
     die "GNU tar required (macOS: brew install gnu-tar)"
 fi
@@ -156,6 +168,50 @@ NEW_ID=$(cat published-contract/contract-id.txt)
 echo
 echo "── new contract id: $NEW_ID ────────────────────────────────"
 
+# ─── 4b. Facade pointer flip (issue #45 Phase 3) ──────────────────────────────
+#
+# The web-container contract id rotates every release, orphaning bookmarks.
+# Users hit the FACADE contract instead — a stable, bookmarkable id whose
+# signed state points at the current release's webapp. Each release we
+# re-render the loader with the new current_app_id baked in, sign a fresh
+# facade state (bumped version, production key — same key the web-container
+# uses), and UPDATE the facade contract via `fdev --as-state`.
+#
+# Conditional: only runs once published-contract/facade-id.txt exists (the
+# facade has been published once and its id committed — see RELEASING.md
+# §"One-time facade publish"). Until then it warns + skips so the rest of
+# the release still proceeds.
+if [ -f published-contract/facade-id.txt ]; then
+    FACADE_ID=$(tr -d '[:space:]' < published-contract/facade-id.txt)
+    echo
+    echo "── flipping facade pointer (issue #45) ───────────────────────────────────"
+    echo "  facade contract id: $FACADE_ID"
+    echo "  pointing at:        $NEW_ID"
+
+    FACADE_CURRENT_APP_ID="$NEW_ID" cargo make build-facade-loader
+    cargo make sign-facade-state
+
+    FACADE_STATE="$ROOT/target/facade/facade.state"
+    [ -f "$FACADE_STATE" ] || die "facade state not produced at $FACADE_STATE — sign step failed?"
+
+    if confirm "Push facade UPDATE to the network now?"; then
+        # --as-state: facade update_state only matches UpdateData::State; without
+        # it fdev sends UpdateData::Delta and the contract rejects InvalidUpdate.
+        fdev execute update --as-state "$FACADE_ID" "$FACADE_STATE"
+        echo "  ✓ facade UPDATEd — bookmarked URL stays stable across releases"
+    else
+        echo "  ⚠️  skipped facade flip — webapp $NEW_ID is published but the facade still"
+        echo "      points at the previous release. Resume manually with:"
+        echo "        FACADE_CURRENT_APP_ID=$NEW_ID cargo make sign-facade-state"
+        echo "        fdev execute update --as-state $FACADE_ID $FACADE_STATE"
+    fi
+else
+    echo
+    echo "  ⚠️  published-contract/facade-id.txt not committed — skipping facade flip."
+    echo "      Publish the facade once (RELEASING.md §\"One-time facade publish\")"
+    echo "      and commit its id to enable the stable bookmarkable URL."
+fi
+
 # ─── 5. Snapshot diff (unchanged-bytes is OK) ──────────────────────────────────
 SNAPSHOT_CHANGED=1
 if git diff --quiet -- published-contract/; then
@@ -218,6 +274,14 @@ echo
 echo "── released $TAG ──────────────────────────────────────────────────────────"
 echo "  contract id:     $NEW_ID"
 echo "  signed version:  $WEBAPP_VERSION"
+if [ -f published-contract/facade-id.txt ]; then
+    echo "  facade id:       $(tr -d '[:space:]' < published-contract/facade-id.txt) (stable bookmarkable URL)"
+fi
 echo
 echo "Next: wait ~30s for propagation, then"
 echo "  scripts/smoke-test-production.sh"
+if [ -f published-contract/facade-id.txt ]; then
+    echo
+    echo "Smoke-test the STABLE facade URL (what users bookmark — survives releases):"
+    echo "  http://127.0.0.1:${FREENET_PORT}/v1/contract/web/$(tr -d '[:space:]' < published-contract/facade-id.txt)/"
+fi


### PR DESCRIPTION
Closes the remaining facade phases (issue #45). Builds on merged #46 (contract+types) and #47 (loader+signer+Makefile).

## Phase 3 — per-release pointer flip (`scripts/release.sh`)
The web-container id rotates every release, orphaning bookmarks. The facade is a stable-id contract whose signed state points at the current webapp. This wires the flip into the release driver:

- After the webapp publish, re-render the loader with the new `current_app_id`, sign a fresh facade state (`WEBAPP_VERSION`, production key — same key the web-container uses), and `fdev execute update --as-state <FACADE_ID> facade.state`.
- Conditional on `published-contract/facade-id.txt` existing — warns + skips until the facade is published once.
- Preflight asserts the installed `fdev` supports `--as-state` (only when the facade is in play). Without it, `fdev` sends `UpdateData::Delta`, the contract rejects `InvalidUpdate`, and the pointer silently never moves.
- Final summary + smoke-test hint surface the stable facade URL.

## Phase 4 — Linux byte-equality gate
The facade id = `hash(facade.wasm, facade.parameters)`; `facade.wasm` must stay byte-stable or the id (= bookmarkable URL) rotates.

- `scripts/check-facade-byte-equal.sh` — rebuilds `facade.wasm`, compares to the committed snapshot. **Canonical on linux/amd64 only**; warn-skips on macOS/arm64 and when the snapshot is absent (no-op until bootstrap).
- `scripts/build-facade-snapshot-linux.sh` — deliberate snapshot regen on a native linux/amd64 host; documents the CI-artifact bootstrap path for macOS devs.
- `check-contract-wasm.yml` — facade verify step + `facade-wasm-rebuilt-<sha>` artifact upload on drift.

## RELEASING.md
Full facade section: architecture, one-time publish, per-release flip, verification, manual recovery, loader template + postMessage rationale, canonical-wasm caveat.

## Why no committed facade snapshot in this PR
`facade.parameters` is the 32-byte production verifying key; `facade-id.txt` derives from it. There is no production facade key in the repo or CI (facade reuses the web-container production key, an operator-only secret). The prod snapshot is minted once at the operator's first `cargo make publish-facade` ceremony and committed then. The Phase 4 gate no-ops until that snapshot lands, so this PR is safe to merge with the gate inert.

## Verification
- `bash -n` on all three scripts; YAML lint on the workflow.
- Full sign chain run locally with the test key: `build-facade-loader → pack-facade-loader → sign-facade-state-test` → valid state (version 32, correct app id).
- `cargo test -p web-container-sign` green incl. `facade_integration` (signer output validates against the on-chain `FacadeContract::validate_state`).
- Gate dry-run on this macOS host warn-skips correctly (missing snapshot + non-canonical host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)