### PR TITLE
test(e2e): node-backed browser E2E tier (first slice)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_MAKE_VERSION: "0.37.18"
   FDEV_VERSION: "0.3.212"
+  # Node binary for the node-backed E2E tier. Keep roughly in lockstep with
+  # FDEV_VERSION (same Freenet release line).
+  FREENET_VERSION: "0.2.68"
 
 jobs:
   build-and-test:
@@ -124,5 +127,76 @@ jobs:
           name: playwright-report
           path: |
             web/tests/playwright-report
+            web/tests/test-results
+          retention-days: 14
+
+  # Node-backed E2E: boots a real Freenet node, publishes the webapp + identity
+  # delegate + shards, and drives the SERVED app through Playwright (the only
+  # tier exercising browser -> live node -> delegate -> contract). Heavier than
+  # the offline tiers and depends on an external node binary, so it is
+  # NON-BLOCKING (continue-on-error) — a signal job, not a merge gate. Tracked in
+  # issue #34.
+  node-e2e:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: |
+            web/package-lock.json
+            web/tests/package-lock.json
+      - name: Cache cargo-installed binaries
+        id: cache-bins
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-make
+            ~/.cargo/bin/cargo-binstall
+            ~/.cargo/bin/fdev
+            ~/.cargo/bin/freenet
+            ~/.cargo/bin/b3sum
+          key: ${{ runner.os }}-cargo-bins-make-${{ env.CARGO_MAKE_VERSION }}-fdev-${{ env.FDEV_VERSION }}-fn-${{ env.FREENET_VERSION }}-nodee2e
+      - name: Install cargo-binstall
+        if: steps.cache-bins.outputs.cache-hit != 'true'
+        uses: taiki-e/install-action@cargo-binstall
+      - name: Install cargo-make + fdev + freenet + b3sum
+        if: steps.cache-bins.outputs.cache-hit != 'true'
+        run: |
+          cargo binstall -y --force --version ${{ env.CARGO_MAKE_VERSION }} cargo-make
+          cargo binstall -y --force --version ${{ env.FDEV_VERSION }} fdev || \
+            cargo install fdev --version ${{ env.FDEV_VERSION }} --locked
+          cargo binstall -y --force --version ${{ env.FREENET_VERSION }} freenet || \
+            cargo install freenet --version ${{ env.FREENET_VERSION }} --locked
+          cargo binstall -y --force b3sum || cargo install b3sum --locked
+      - name: Install web + test npm deps
+        run: |
+          npm install --prefix web
+          npm install --prefix web/tests
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-1.48.0-chromium-nodee2e
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: web/tests
+      - name: Run node-backed E2E
+        run: PLAYWRIGHT_PROJECT=chromium cargo make test-ui-node-e2e
+      - name: Upload node-e2e report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-node
+          path: |
+            web/tests/playwright-report-node
             web/tests/test-results
           retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ web/model_code_hash.txt
 # Playwright
 web/tests/node_modules/
 web/tests/playwright-report/
+web/tests/playwright-report-node/
 web/tests/test-results/
 .playwright-mcp/
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -531,6 +531,15 @@ fi
 cd "$ROOT/web/tests" && BASE_URL="http://localhost:$PORT" npx playwright test
 '''
 
+[tasks.test-ui-node-e2e]
+description = "Node-backed E2E: boot a throwaway node, publish, run Playwright against the SERVED webapp, tear down"
+dependencies = ["build", "build-contracts"]
+script_runner = "bash"
+script = '''
+set -euo pipefail
+bash "${CARGO_MAKE_WORKING_DIRECTORY}/scripts/node-e2e.sh"
+'''
+
 [tasks.clean-node]
 description = "Wipe local Freenet node state (macOS paths). Stop the node first."
 script_runner = "bash"

--- a/docs/adr/0001-implementation-notes.md
+++ b/docs/adr/0001-implementation-notes.md
@@ -589,15 +589,30 @@ per-slice reviews could not see:
   like / non-owner post in a peer's state must not propagate to an honest
   replica), and cross-shard key consistency (a user-shard post's content id is the
   thread-shard param, and a reply bound to it lands only on that thread).
-- **Deferred — WASM-in-node e2e**: these integration tests drive the contract as a
-  Rust library, not the compiled WASM inside a running node, so they do not catch
-  WASM-compilation or transport differences. A real-node tier (via the
-  `freenet:linux-test` / `freenet:local-dev` skills — publish the shards, drive
-  reply/like/quote + two-peer sync over the live WS) is the next testing slice;
-  it is heavier and not a per-PR CI fit. It is the only tier that can confirm the
-  load-bearing `ensureThreadShard` GET-rejects-on-uninstantiated assumption above
-  and catch WASM-trap / node-vs-JS key-derivation drift. **Tracked as issue #34**
-  (not only this note).
+- **Node-backed browser E2E (first slice landed).** `scripts/node-e2e.sh` +
+  `cargo make test-ui-node-e2e` boot a fresh, isolated Freenet node, publish the
+  identity delegate + packaged web container + shards to it, and run the
+  Playwright specs under `web/tests/node-e2e/` against the node-SERVED webapp
+  (`/v1/contract/web/<CID>/`). This is the only tier that exercises the real
+  browser → live node → delegate → contract path: the served loader mounts the
+  app in a sandboxed iframe, opens a live WS to `/v1/contract/command`, wires the
+  identity delegate, and drives onboarding → identity → app-shell. Live-delegate
+  console signals (`Connected to Freenet node`, `Delegate connection wired`,
+  `No identity in delegate — show onboarding`) are asserted so a spec cannot pass
+  in offline/mock mode. Runs as a **non-blocking** CI job (`node-e2e`,
+  `continue-on-error`) since it needs an external node binary and is heavier than
+  per-PR gating. Does **not yet** confirm delegate identity *persistence* across
+  reload, the GET-rejects-on-uninstantiated assumption, WASM-trap, or node-vs-JS
+  key-derivation drift — those stay in the contract tier below.
+- **Deferred — WASM-in-node contract e2e**: the contract `integration` tests drive
+  the contract as a Rust library, not the compiled WASM inside a running node, so
+  they do not catch WASM-compilation or transport differences. A contract-level
+  real-node tier (via the `freenet:linux-test` / `freenet:local-dev` skills —
+  publish the shards, drive reply/like/quote + two-peer sync over the live WS) is
+  the next slice beneath the browser E2E above. It is the only tier that can
+  confirm the load-bearing `ensureThreadShard` / `ensureGlobalIndex`
+  GET-rejects-on-uninstantiated assumption and catch WASM-trap / node-vs-JS
+  key-derivation drift. **Tracked as issue #34** (not only this note).
 - **Delegate unit coverage (added in the holistic-review pass).** The identity
   delegate now has unit tests (`delegates/identity/src/lib.rs`): export→import seed
   round-trip, and the delegate's `SignPost`/`SignLike` outputs verify under the

--- a/scripts/node-e2e.sh
+++ b/scripts/node-e2e.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Node-backed end-to-end test harness.
+#
+# Boots a FRESH, ISOLATED Freenet node (its own --config-dir / --data-dir, on a
+# non-default port so it never touches a developer's running dev node), publishes
+# the identity delegate + the packaged web container + the shard contracts to it,
+# then runs the Playwright specs under web/tests/node-e2e/ against the node-SERVED
+# webapp URL (http://127.0.0.1:<port>/v1/contract/web/<CID>/).
+#
+# This is the only tier that exercises the real browser -> live node -> delegate
+# -> contract stack: WS connect, delegate identity flow, shard PUT/GET/UPDATE
+# against compiled WASM in a node. The offline Playwright job (test-ui-playwright)
+# only renders mock data and never touches a node. See issue #34 + docs/adr.
+#
+# Requires: the `freenet` node binary AND `fdev` on PATH (the offline tier needs
+# only fdev). Heavier than per-PR CI — intended as a separate, non-blocking job.
+#
+# Env overrides:
+#   E2E_WS_PORT   websocket api port for the throwaway node (default 7609)
+#   E2E_KEEP      if set, do not delete the temp node dir on exit (for debugging)
+#   PLAYWRIGHT_PROJECT  limit to one browser, e.g. "chromium" (default: all)
+
+set -euo pipefail
+
+ROOT="${CARGO_MAKE_WORKING_DIRECTORY:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+PORT="${E2E_WS_PORT:-7609}"
+
+command -v freenet >/dev/null 2>&1 || { echo "ERROR: 'freenet' node binary not on PATH" >&2; exit 1; }
+command -v fdev    >/dev/null 2>&1 || { echo "ERROR: 'fdev' not on PATH" >&2; exit 1; }
+
+E2E_DIR="$(mktemp -d "${TMPDIR:-/tmp}/raven-node-e2e.XXXXXX")"
+mkdir -p "$E2E_DIR/config" "$E2E_DIR/data"
+
+NODE_PID=""
+
+# The publish steps (update-published-contract / sign-webapp-test) REWRITE the
+# committed release snapshot under published-contract/ and web/dist/. Those are
+# tracked artifacts that must not change as a side effect of running tests, so we
+# snapshot them up front and restore on exit. (The throwaway node's own state
+# lives entirely under $E2E_DIR and is just deleted.)
+SNAP_DIR="$E2E_DIR/_committed_snapshot"
+mkdir -p "$SNAP_DIR"
+[ -d "$ROOT/published-contract" ] && cp -R "$ROOT/published-contract" "$SNAP_DIR/published-contract"
+[ -f "$ROOT/web/dist/index.html" ] && { mkdir -p "$SNAP_DIR/dist"; cp "$ROOT/web/dist/index.html" "$SNAP_DIR/dist/index.html"; }
+
+cleanup() {
+    [ -n "$NODE_PID" ] && kill "$NODE_PID" 2>/dev/null || true
+    # Restore the committed release snapshot the publish steps mutated.
+    [ -d "$SNAP_DIR/published-contract" ] && { rm -rf "$ROOT/published-contract"; cp -R "$SNAP_DIR/published-contract" "$ROOT/published-contract"; }
+    [ -f "$SNAP_DIR/dist/index.html" ] && cp "$SNAP_DIR/dist/index.html" "$ROOT/web/dist/index.html"
+    if [ -n "${E2E_KEEP:-}" ]; then
+        echo "E2E_KEEP set — leaving node dir: $E2E_DIR"
+    else
+        rm -rf "$E2E_DIR"
+    fi
+}
+trap cleanup EXIT
+
+echo "── booting throwaway Freenet node on 127.0.0.1:$PORT (dir: $E2E_DIR) ──"
+# IPv4 bind (--ws-api-address 127.0.0.1): fdev publish dials 127.0.0.1, and the
+# default dual-stack bind comes up IPv6-only on some hosts -> connection refused.
+RUST_LOG="${RUST_LOG:-freenet=warn,info}" freenet local \
+    --ws-api-address 127.0.0.1 --ws-api-port "$PORT" \
+    --config-dir "$E2E_DIR/config" --data-dir "$E2E_DIR/data" \
+    > "$E2E_DIR/node.log" 2>&1 &
+NODE_PID=$!
+
+# Wait for the WS API to accept connections.
+ready=false
+for _ in $(seq 1 60); do
+    if curl -sS -m1 "http://127.0.0.1:$PORT/" >/dev/null 2>&1; then ready=true; break; fi
+    if ! kill -0 "$NODE_PID" 2>/dev/null; then
+        echo "ERROR: node process exited during startup" >&2
+        tail -30 "$E2E_DIR/node.log" >&2; exit 1
+    fi
+    sleep 1
+done
+[ "$ready" = true ] || { echo "ERROR: node WS api not ready within 60s" >&2; tail -30 "$E2E_DIR/node.log" >&2; exit 1; }
+echo "node listening."
+
+# Publish to THIS node. fdev resolves the node port from WS_API_PORT.
+export WS_API_PORT="$PORT"
+
+echo "── snapshotting + publishing identity delegate ──"
+# update-published-contract records the test-signed web container + contract id.
+cargo make update-published-contract
+cargo make publish-identity
+
+echo "── publishing packaged web container ──"
+cargo make publish-webapp-test
+
+CID="$(cat "$ROOT/published-contract/contract-id.txt")"
+APP_URL="http://127.0.0.1:$PORT/v1/contract/web/$CID/"
+echo "── webapp published. served at: $APP_URL ──"
+
+# Wait for the served webapp GET to return the packaged HTML (not the node's
+# "FN Peer" status page on /).
+served=false
+for _ in $(seq 1 30); do
+    code="$(curl -sS -m5 -o /dev/null -w '%{http_code}' "$APP_URL" 2>/dev/null || true)"
+    if [ "$code" = "200" ]; then served=true; break; fi
+    sleep 2
+done
+[ "$served" = true ] || { echo "ERROR: served webapp not reachable (last http=$code)" >&2; exit 1; }
+
+echo "── running node-e2e Playwright specs ──"
+cd "$ROOT/web/tests"
+proj_args=()
+[ -n "${PLAYWRIGHT_PROJECT:-}" ] && proj_args=(--project="$PLAYWRIGHT_PROJECT")
+BASE_URL="$APP_URL" npx playwright test --config=playwright.node.config.ts "${proj_args[@]}"

--- a/web/tests/node-e2e/live-node.spec.ts
+++ b/web/tests/node-e2e/live-node.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type Page, type FrameLocator } from "@playwright/test";
+
+// End-to-end against a LIVE Freenet node (booted + published by
+// scripts/node-e2e.sh). Unlike the offline tier these exercise the real stack:
+// the node serves the packaged web container, which mounts the app inside a
+// sandboxed <iframe id="app"> (the freenetBridge loader), opens a WebSocket to
+// the node's /v1/contract/command, wires the identity delegate, and drives the
+// onboarding -> identity -> feed flow against compiled WASM in the node.
+//
+// The app lives INSIDE the iframe, so UI assertions go through frameLocator.
+
+/** The packaged app runs inside the sandboxed loader iframe. */
+function app(page: Page): FrameLocator {
+  return page.frameLocator("iframe#app");
+}
+
+/** Collect WS urls + console for connection assertions. */
+function instrument(page: Page) {
+  const ws: string[] = [];
+  const logs: string[] = [];
+  page.on("websocket", (s) => ws.push(s.url()));
+  page.on("console", (m) => logs.push(`[${m.type()}] ${m.text()}`));
+  page.on("pageerror", (e) => logs.push(`[pageerror] ${e.message}`));
+  return { ws, logs };
+}
+
+test.beforeEach(({ baseURL }) => {
+  // baseURL is the node-served contract URL injected by the harness; fail loud
+  // if a human ran this config directly without the harness.
+  expect(
+    baseURL,
+    "BASE_URL must be the node-served webapp URL — run via `cargo make test-ui-node-e2e`",
+  ).toBeTruthy();
+});
+
+test("node serves the packaged web container (loader + sandbox iframe)", async ({ page }) => {
+  // goto("") navigates to baseURL verbatim. goto("/") would resolve to the
+  // ORIGIN root (dropping the /v1/contract/web/<CID>/ path) and hit the node's
+  // "FN Peer" status page instead of the served webapp.
+  await page.goto("", { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveTitle("Freenet", { timeout: 20_000 });
+  // The loader wraps the app in a sandboxed iframe pointing back at the contract.
+  const iframe = page.locator("iframe#app");
+  await expect(iframe).toHaveAttribute("src", /\/v1\/contract\/web\/.+__sandbox=1/, {
+    timeout: 20_000,
+  });
+});
+
+test("app connects to the live node over the websocket API + wires the delegate", async ({
+  page,
+}) => {
+  const { ws, logs } = instrument(page);
+  // goto("") navigates to baseURL verbatim. goto("/") would resolve to the
+  // ORIGIN root (dropping the /v1/contract/web/<CID>/ path) and hit the node's
+  // "FN Peer" status page instead of the served webapp.
+  await page.goto("", { waitUntil: "domcontentloaded" });
+
+  // The packaged app (NOT the offline mock) opens a real WS to the node.
+  await expect
+    .poll(() => ws.some((u) => u.includes("/v1/contract/command")), { timeout: 30_000 })
+    .toBeTruthy();
+
+  // And reports a live connection + a wired identity delegate in-page.
+  await expect
+    .poll(() => logs.some((l) => l.includes("Connected to Freenet node")), { timeout: 30_000 })
+    .toBeTruthy();
+  await expect
+    .poll(() => logs.some((l) => l.includes("[identity] Delegate connection wired")), {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+});
+
+test("fresh delegate replies 'no identity' over the live API -> onboarding renders", async ({
+  page,
+}) => {
+  const { logs } = instrument(page);
+  // goto("") navigates to baseURL verbatim. goto("/") would resolve to the
+  // ORIGIN root (dropping the /v1/contract/web/<CID>/ path) and hit the node's
+  // "FN Peer" status page instead of the served webapp.
+  await page.goto("", { waitUntil: "domcontentloaded" });
+
+  // The decisive assertion that this is a LIVE node (not offline mock, not a
+  // cached DOM): the app received a real delegate response and decided to show
+  // onboarding because of it. Offline mode logs "[offline] Booting…" and never
+  // queries a delegate, so this signal cannot appear without a live node.
+  await expect
+    .poll(() => logs.some((l) => l.includes("[identity] No identity in delegate — show onboarding")), {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+
+  // …and the onboarding UI is what the user actually sees inside the iframe.
+  await expect(app(page).locator(".onboarding-overlay")).toBeVisible({ timeout: 10_000 });
+  await expect(app(page).locator(".onboarding-title")).toContainText("Welcome to Raven", {
+    timeout: 10_000,
+  });
+});
+
+test("creating an identity advances past onboarding to the app shell", async ({ page }) => {
+  const { logs } = instrument(page);
+  // goto("") navigates to baseURL verbatim. goto("/") would resolve to the
+  // ORIGIN root (dropping the /v1/contract/web/<CID>/ path) and hit the node's
+  // "FN Peer" status page instead of the served webapp.
+  await page.goto("", { waitUntil: "domcontentloaded" });
+  const a = app(page);
+
+  // Wait for the live "show onboarding" decision before interacting, so we know
+  // the app is past delegate-wiring and not mid-boot.
+  await expect
+    .poll(() => logs.some((l) => l.includes("[identity] No identity in delegate — show onboarding")), {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+  await expect(a.locator(".onboarding-overlay")).toBeVisible({ timeout: 10_000 });
+
+  // Type a display name and Join. NOTE: the app renders the shell client-side on
+  // Join (createIdentity -> renderApp) and fires the delegate CreateIdentity
+  // write asynchronously; this asserts the onboarding->app UI transition against
+  // the node-served build. (Verifying the delegate actually PERSISTED the
+  // identity across a reload is the deeper #34 tier.)
+  await a.locator(".onboarding-input").first().fill("E2E Tester");
+  const join = a.locator(".onboarding-btn", { hasText: "Join" });
+  await expect(join).toBeEnabled({ timeout: 10_000 });
+  await join.click();
+
+  await expect(a.locator(".onboarding-overlay")).toBeHidden({ timeout: 45_000 });
+  await expect(a.locator("aside.sidebar")).toBeVisible({ timeout: 45_000 });
+});

--- a/web/tests/playwright.config.ts
+++ b/web/tests/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: ".",
+  // node-e2e/ specs require a live node (run via playwright.node.config.ts +
+  // scripts/node-e2e.sh); the offline tier must never pick them up.
+  testIgnore: "**/node-e2e/**",
   timeout: 30_000,
   fullyParallel: true,
   reporter: [["html", { outputFolder: "playwright-report", open: "never" }]],

--- a/web/tests/playwright.node.config.ts
+++ b/web/tests/playwright.node.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Node-backed E2E config: specs under node-e2e/ run against the webapp SERVED BY
+// a live Freenet node (BASE_URL points at http://127.0.0.1:<port>/v1/contract/
+// web/<CID>/). Driven by scripts/node-e2e.sh, which boots the node + publishes.
+// Kept separate from playwright.config.ts (the offline tier) so the offline job
+// never tries to run these and vice-versa.
+//
+// Timeouts are larger than the offline config: a real node round-trip (WS
+// connect, delegate query, contract PUT/GET) is slower than rendering mock data.
+export default defineConfig({
+  testDir: "./node-e2e",
+  timeout: 90_000,
+  expect: { timeout: 30_000 },
+  // Real node state is shared across specs in one published instance; keep it
+  // serial so an identity created by one spec can't race another's assertions.
+  fullyParallel: false,
+  workers: 1,
+  retries: 1,
+  reporter: [["list"], ["html", { outputFolder: "playwright-report-node", open: "never" }]],
+  use: {
+    baseURL: process.env.BASE_URL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+});


### PR DESCRIPTION
## Why

Raven had **no true E2E coverage**. The layers stopped short of the real stack:
- Rust contract tests drive WASM as a **Rust library**, not in a node.
- vitest mocks the WS API.
- Playwright runs the **offline mock build** (no node) — asserts rendering, never a round-trip.

Nothing exercised **browser → live node → delegate → contract** — exactly where the load-bearing seams live (the `ensure*` GET-then-PUT singleton hazard, delegate signing, WASM traps).

## What (first slice)

A node-backed browser E2E tier that boots a **real Freenet node** and drives the **node-served** webapp:

- **`scripts/node-e2e.sh`** — fresh isolated node (temp `--config-dir`/`--data-dir`, non-default port, IPv4 bind), publishes identity delegate + web container + shards, waits for the served webapp, runs Playwright against `/v1/contract/web/<CID>/`, tears down. **Snapshots + restores** committed `published-contract/` + `web/dist/` so a run never mutates tracked release artifacts.
- **`cargo make test-ui-node-e2e`** + **`web/tests/playwright.node.config.ts`** (separate `testDir: node-e2e/`, serial, longer timeouts). Offline config now `testIgnore`s `node-e2e/`.
- **`web/tests/node-e2e/live-node.spec.ts`** (4 specs): serves loader+sandbox iframe; live WS to `/v1/contract/command` + delegate wired; fresh delegate → "no identity" → onboarding; create identity → app shell. **Live-delegate console signals are asserted**, so a spec cannot pass in offline/mock mode.
- **CI** — **non-blocking** `node-e2e` job (`continue-on-error`) installing the `freenet` node binary + `fdev`, chromium only.
- **docs/adr** — documents the tier + what it does/doesn't yet verify.

## Verified locally

Full harness on a fresh node, 4/4 green (real live-delegate flow):
```
✓ node serves the packaged web container (loader + sandbox iframe)
✓ app connects to the live node over the websocket API + wires the delegate
✓ fresh delegate replies 'no identity' over the live API -> onboarding renders
✓ creating an identity advances past onboarding to the app shell
```
Offline tier still green on chromium and correctly **ignores** `node-e2e/` (firefox/webkit fail locally only due to missing browser binaries — CI installs all three).

## Scope / still deferred (tracked in #50, #34)

Does **not yet** verify: delegate identity **persistence** across reload, the **GET-rejects-on-uninstantiated** assumption (`ensureThreadShard`/`ensureGlobalIndex`), WASM-trap, node-vs-JS key-derivation drift, two-peer sync, global-index share read-back. Those are the deeper contract tier.

Refs #50, #34