### PR TITLE
feat(global-index): read/render public timeline + live E2E (#49 follow-up)

### DIFF
--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -19,7 +19,10 @@ export interface AppCallbacks {
   reply?: (rootPostId: string, content: string) => void;
 }
 
-type FeedEl = HTMLElement & { updatePosts: (p: Post[]) => void };
+type FeedEl = HTMLElement & {
+  updatePosts: (p: Post[]) => void;
+  updateDiscoverPosts: (p: Post[]) => void;
+};
 
 export function createApp(cb: AppCallbacks): HTMLElement {
   const posts: Post[] = [];
@@ -152,6 +155,7 @@ export function createApp(cb: AppCallbacks): HTMLElement {
   // Public surface used by index.ts to push updates.
   const appEl = app as unknown as HTMLElement & {
     updatePosts: (updatedPosts: Post[]) => void;
+    updateGlobalPosts: (updatedPosts: Post[]) => void;
     addPost: (post: Post) => void;
   };
 
@@ -159,6 +163,10 @@ export function createApp(cb: AppCallbacks): HTMLElement {
     posts.length = 0;
     posts.push(...updatedPosts);
     feed.updatePosts(updatedPosts);
+  };
+
+  appEl.updateGlobalPosts = (updatedPosts: Post[]) => {
+    feed.updateDiscoverPosts(updatedPosts);
   };
 
   appEl.addPost = (post: Post) => {

--- a/web/src/components/feed.ts
+++ b/web/src/components/feed.ts
@@ -99,17 +99,43 @@ export function createFeed(
   postList.className = "feed__posts";
 
   let currentPosts: Post[] = [...initialPosts];
+  // Public-timeline (global-index) posts, shown under the Discover tab.
+  let discoverPosts: Post[] = [];
 
   function renderPosts(): void {
     postList.innerHTML = "";
     if (activeTab === "discover") {
-      const note = document.createElement("div");
-      note.className = "following-note";
-      note.innerHTML = `
-        <div class="following-note__title">Discover is quiet right now</div>
-        <div class="following-note__sub">New voices from across the network will surface here as you explore.</div>
-      `;
-      postList.appendChild(note);
+      if (discoverPosts.length === 0) {
+        const note = document.createElement("div");
+        note.className = "following-note";
+        note.innerHTML = `
+          <div class="following-note__title">No public posts yet</div>
+          <div class="following-note__sub">Public posts from across the network will appear here.</div>
+        `;
+        postList.appendChild(note);
+        return;
+      }
+
+      // Best-effort quoted-card resolution: only over discoverPosts. A quote
+      // whose target is not in the public timeline (e.g. a reply — those are
+      // filtered out upstream, or a post not present in the global index)
+      // renders without its quoted card. Richer resolution would need a
+      // per-target thread-shard fetch; out of scope for the read/render slice.
+      const resolveQuoted = (id: string): Post | undefined =>
+        discoverPosts.find((p) => p.id === id);
+
+      discoverPosts.forEach((post, i) => {
+        postList.appendChild(
+          createPostCard(post, {
+            onLike: callbacks.onLike,
+            onRepost: callbacks.onRepost,
+            onQuote: callbacks.onQuote,
+            onOpen: callbacks.onOpen,
+            resolveQuoted,
+            lead: i === 0,
+          }),
+        );
+      });
       return;
     }
 
@@ -163,11 +189,16 @@ export function createFeed(
   const feedEl = feed as HTMLElement & {
     postList: HTMLDivElement;
     updatePosts: (posts: Post[]) => void;
+    updateDiscoverPosts: (posts: Post[]) => void;
   };
   feedEl.postList = postList;
   feedEl.updatePosts = (updatedPosts: Post[]) => {
     currentPosts = updatedPosts;
     renderPosts();
+  };
+  feedEl.updateDiscoverPosts = (updatedPosts: Post[]) => {
+    discoverPosts = updatedPosts;
+    if (activeTab === "discover") renderPosts();
   };
 
   return feed;

--- a/web/src/freenet-api.test.ts
+++ b/web/src/freenet-api.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { GetRequest, GetResponse } from "@freenetorg/freenet-stdlib";
+import type {
+  GetRequest,
+  GetResponse,
+  UpdateNotification,
+} from "@freenetorg/freenet-stdlib";
+import { UpdateDataType } from "@freenetorg/freenet-stdlib";
 
 // ---------------------------------------------------------------------------
 // Mocking approach
@@ -123,6 +128,8 @@ function makeConnection() {
     onLikeUpdated: ReturnType<typeof vi.fn>;
     onRepostUpdated: ReturnType<typeof vi.fn>;
     onQuoteUpdated: ReturnType<typeof vi.fn>;
+    onGlobalPostsLoaded: ReturnType<typeof vi.fn>;
+    onNewGlobalPost: ReturnType<typeof vi.fn>;
   } = {
     onPostsLoaded: vi.fn(),
     onNewPost: vi.fn(),
@@ -130,6 +137,8 @@ function makeConnection() {
     onLikeUpdated: vi.fn(),
     onRepostUpdated: vi.fn(),
     onQuoteUpdated: vi.fn(),
+    onGlobalPostsLoaded: vi.fn(),
+    onNewGlobalPost: vi.fn(),
   };
   const conn = new FreenetConnection(callbacks as unknown as FreenetCallbacks);
   conn.connect();
@@ -766,6 +775,205 @@ describe("FreenetConnection", () => {
       expect(reEmit.postId).toBe(rootId);
       expect(reEmit.count).toBe(2); // two reposted:true records
       expect(reEmit.repostedByMe).toBe(true); // owner is among them
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Global-index (public-timeline) READ path.
+  // -------------------------------------------------------------------------
+  // The write side (shareToGlobalIndex / ensureGlobalIndex) already has the
+  // singleton key wiring; these cover the read side: loadGlobalIndex() issues a
+  // serialised GET against the singleton key, handleGetResponse routes that
+  // response (state = a MAP keyed by id, a Rust BTreeMap) to onGlobalPostsLoaded,
+  // and a live update notification with a `{"Posts":[…]}` delta on that same key
+  // routes to onNewGlobalPost. We drive everything through the captured handler
+  // exactly like the user-shard/thread GET tests above.
+  describe("global-index read path", () => {
+    // A ContractPost as it appears on-wire inside the global index map. Mirrors
+    // the Rust `Post` json fields (incl. `reply_to`). `id` is the map key.
+    function gPost(
+      overrides: Partial<{
+        id: string;
+        content: string;
+        timestamp: number;
+        reply_to: string;
+      }> = {},
+    ): Record<string, unknown> {
+      return {
+        id: overrides.id ?? "g1",
+        author_pubkey: OWNER_VK,
+        author_name: "Alice",
+        author_handle: "alice",
+        content: overrides.content ?? "hello timeline",
+        timestamp: overrides.timestamp ?? 1000,
+        reply_to: overrides.reply_to ?? "",
+        quoted_post: "",
+        signature: "sig",
+      };
+    }
+
+    /** Encode a global-index state map ({"posts": {<id>: Post}}) as state bytes. */
+    function globalStateBytes(posts: Record<string, unknown>): number[] {
+      return Array.from(
+        new TextEncoder().encode(JSON.stringify({ posts })),
+      );
+    }
+
+    /**
+     * Trigger loadGlobalIndex() and return the GET it issued. The hash file is
+     * present in the repo, so __GLOBAL_INDEX_SHARD_CODE_HASH__ is a real hash and
+     * globalIndexKeyOrNull() derives + registers the singleton instance id — so
+     * the response we feed back routes to the global-index branch.
+     */
+    async function loadGlobalAndGetProbe(
+      conn: FreenetConnection,
+      api: FakeWsApi,
+    ): Promise<Deferred<GetResponse>> {
+      const before = api.getCalls.length;
+      conn.loadGlobalIndex();
+      await flush();
+      expect(api.getCalls.length).toBe(before + 1);
+      return api.getCalls[api.getCalls.length - 1];
+    }
+
+    it("a global-index GET maps the posts MAP and emits onGlobalPostsLoaded newest-first", async () => {
+      const { conn, api, callbacks } = makeConnection();
+      const probe = await loadGlobalAndGetProbe(conn, api);
+
+      // Two top-level posts keyed by id; the older one is listed first in the
+      // map to prove the read side sorts by timestamp desc (not map order).
+      const posts = {
+        old: gPost({ id: "old", content: "older", timestamp: 1000 }),
+        new: gPost({ id: "new", content: "newer", timestamp: 5000 }),
+      };
+      api.handler.onContractGet({
+        key: probe.req.key,
+        state: globalStateBytes(posts),
+      } as unknown as GetResponse);
+
+      expect(callbacks.onGlobalPostsLoaded).toHaveBeenCalledTimes(1);
+      const emitted = callbacks.onGlobalPostsLoaded.mock.calls[0][0] as Array<{
+        id: string;
+        content: string;
+      }>;
+      expect(emitted.map((p) => p.id)).toEqual(["new", "old"]); // newest first
+      expect(emitted[0].content).toBe("newer");
+
+      // Routing isolation: the user-shard callback must NOT fire for this GET.
+      expect(callbacks.onPostsLoaded).not.toHaveBeenCalled();
+    });
+
+    it("an empty index ({\"posts\":{}}) emits onGlobalPostsLoaded([])", async () => {
+      const { conn, api, callbacks } = makeConnection();
+      const probe = await loadGlobalAndGetProbe(conn, api);
+
+      api.handler.onContractGet({
+        key: probe.req.key,
+        state: globalStateBytes({}),
+      } as unknown as GetResponse);
+
+      expect(callbacks.onGlobalPostsLoaded).toHaveBeenCalledTimes(1);
+      expect(callbacks.onGlobalPostsLoaded.mock.calls[0][0]).toEqual([]);
+    });
+
+    it("filters reply posts out of the timeline (top-level only)", async () => {
+      const { conn, api, callbacks } = makeConnection();
+      const probe = await loadGlobalAndGetProbe(conn, api);
+
+      // The index MAY hold replies (acceptance is self-verification only); the
+      // read side filters on a non-empty reply_to to keep the timeline top-level.
+      const posts = {
+        top: gPost({ id: "top", reply_to: "" }),
+        reply: gPost({ id: "reply", reply_to: "some-parent" }),
+      };
+      api.handler.onContractGet({
+        key: probe.req.key,
+        state: globalStateBytes(posts),
+      } as unknown as GetResponse);
+
+      const emitted = callbacks.onGlobalPostsLoaded.mock.calls[0][0] as Array<{
+        id: string;
+      }>;
+      expect(emitted.map((p) => p.id)).toEqual(["top"]);
+    });
+
+    it("a global-index delta notification ({\"Posts\":[…]}) emits onNewGlobalPost", async () => {
+      const { conn, api, callbacks } = makeConnection();
+      // loadGlobalIndex registers the singleton instance id used to route both
+      // the GET response AND subsequent live-update notifications.
+      const probe = await loadGlobalAndGetProbe(conn, api);
+
+      const post = gPost({ id: "live-1", content: "fresh share" });
+      const deltaBytes = Array.from(
+        new TextEncoder().encode(JSON.stringify({ Posts: [post] })),
+      );
+      // The handler reads notification.update as a property-shaped UpdateData
+      // ({ updateDataType, updateData: { delta } }) — same shape the production
+      // unpacked notification exposes; mirror it as a plain object.
+      api.handler.onContractUpdateNotification({
+        key: probe.req.key,
+        update: {
+          updateDataType: UpdateDataType.DeltaUpdate,
+          updateData: { delta: deltaBytes },
+        },
+      } as unknown as UpdateNotification);
+
+      expect(callbacks.onNewGlobalPost).toHaveBeenCalledTimes(1);
+      const emitted = callbacks.onNewGlobalPost.mock.calls[0][0] as {
+        id: string;
+        content: string;
+      };
+      expect(emitted.id).toBe("live-1");
+      expect(emitted.content).toBe("fresh share");
+
+      // Routing isolation: the user-shard live-update callback must NOT fire.
+      expect(callbacks.onNewPost).not.toHaveBeenCalled();
+    });
+
+    it("routing isolation: a user-shard GET does NOT fire the global callback", async () => {
+      const { conn, api, callbacks } = makeConnection();
+
+      // Establish + load the user shard (sets userShardInstanceId, issues GETs).
+      conn.setUser(OWNER_VK, "Alice", "alice");
+      await flush();
+      const probe = api.getCalls[0]; // the user-shard probe GET
+      probe.resolve({} as GetResponse); // exists -> no PUT
+      await flush();
+      await flush();
+      // loadUserShard's GET carries the user-shard state (a Vec under `posts`).
+      expect(api.getCalls.length).toBe(2);
+      const loadGet = api.getCalls[1];
+
+      api.handler.onContractGet({
+        key: loadGet.req.key,
+        state: Array.from(
+          new TextEncoder().encode(
+            JSON.stringify({ posts: [gPost({ id: "u1" })] }),
+          ),
+        ),
+      } as unknown as GetResponse);
+
+      // The user-shard branch fired; the global-index branch must NOT have.
+      expect(callbacks.onPostsLoaded).toHaveBeenCalledTimes(1);
+      expect(callbacks.onGlobalPostsLoaded).not.toHaveBeenCalled();
+    });
+
+    it("loadGlobalIndex() is a no-op before connect() (no GET, no throw)", () => {
+      // globalIndexKeyOrNull() returns null only when the build hash is the dev
+      // sentinel/undefined — which can't be forced here (it's a compile-time
+      // vite `define`). The other no-op guard is `!this.api`: before connect(),
+      // the WS client doesn't exist, so loadGlobalIndex() must quietly return
+      // without issuing a GET (and without throwing). This is the path an
+      // offline/unconnected reader hits.
+      const conn = new FreenetConnection({
+        onPostsLoaded: vi.fn(),
+        onNewPost: vi.fn(),
+        onStatusChange: vi.fn(),
+      } as unknown as FreenetCallbacks);
+      // No connect() — this.api is null.
+      expect(() => conn.loadGlobalIndex()).not.toThrow();
+      // No FakeWsApi instance was created (connect not called) and thus no GET.
+      expect(FakeWsApi.instances.length).toBe(0);
     });
   });
 });

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -36,6 +36,11 @@ interface ContractPost {
   author_handle: string;
   content: string;
   timestamp: number;
+  // Content address of the post this replies to, empty/absent for top-level
+  // posts. Matches the Rust `Post.reply_to` field. The global index MAY hold
+  // replies (its acceptance is self-verification only — see the contract doc),
+  // so a strictly-top-level public timeline filters on this at render time.
+  reply_to?: string;
   // Content address of the quoted post (quote repost), empty/absent otherwise.
   // Matches the Rust `Post.quoted_post` additive field.
   quoted_post?: string;
@@ -65,6 +70,15 @@ interface UserShardState {
   posts?: ContractPost[];
   profile?: unknown;
   follows?: Record<string, unknown>;
+}
+
+// Global-index (public-timeline) state (matches Rust `GlobalIndexShard`). Unlike
+// the user shard, `posts` is a MAP keyed by content-address id (Rust
+// `BTreeMap<String, Post>`), NOT a Vec — so the read side iterates
+// `Object.values(posts)`. `#[serde(default)]` on the contract makes `{}` and
+// `{"posts":{}}` both decode to an empty timeline.
+interface GlobalIndexState {
+  posts?: Record<string, ContractPost>;
 }
 
 // A like record (matches Rust `common::thread::LikeRecord`). signer_pubkey is
@@ -198,6 +212,10 @@ export interface FreenetCallbacks {
   onRepostUpdated?: (repost: RepostState) => void;
   /** Optional: live quote-repost count for a post, from its thread shard. */
   onQuoteUpdated?: (quote: QuoteState) => void;
+  /** Optional: full public-timeline snapshot from the global-index GET. */
+  onGlobalPostsLoaded?: (posts: Post[]) => void;
+  /** Optional: a single live public-timeline post from a global-index delta. */
+  onNewGlobalPost?: (post: Post) => void;
 }
 
 export class FreenetConnection {
@@ -259,6 +277,12 @@ export class FreenetConnection {
    * the first opt-in share; null when no code hash is injected (offline / dev).
    */
   private globalIndexKey: ContractKey | null = null;
+  /**
+   * Base58 instance id of {@link globalIndexKey}, for response key matching on
+   * the read side. Mirrors {@link userShardInstanceId}; set when the singleton
+   * key is first derived in {@link globalIndexKeyOrNull}.
+   */
+  private globalIndexInstanceId: string | null = null;
   /** Set once the global index is confirmed instantiated (GET-probe or PUT). */
   private globalIndexEnsured = false;
   /** Collapses concurrent first-share races into one GET-probe + PUT. */
@@ -406,6 +430,24 @@ export class FreenetConnection {
         this.emitQuoteState(threadRoot, thread.quotes ?? {});
         return;
       }
+      // Global-index GET (public-timeline snapshot): the singleton's state is a
+      // MAP keyed by id (Rust BTreeMap), so iterate `Object.values`, not a Vec.
+      // The index MAY hold replies/quotes (acceptance is self-verification only),
+      // so filter to top-level posts (empty/absent reply_to) before rendering.
+      if (this.globalIndexInstanceId !== null && respId === this.globalIndexInstanceId) {
+        const stateJson = new TextDecoder("utf8").decode(
+          Uint8Array.from(response.state),
+        );
+        const rawPosts = (JSON.parse(stateJson) as GlobalIndexState).posts ?? {};
+        const posts = Object.values(rawPosts)
+          .filter((cp) => !cp.reply_to)
+          .map(contractPostToUiPost);
+        // Sort by timestamp descending (newest first) — same comparator as the
+        // user-shard path.
+        posts.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+        this.callbacks.onGlobalPostsLoaded?.(posts);
+        return;
+      }
       // The only other GET source is the owner's user shard. Drop anything else.
       if (this.userShardInstanceId === null || respId !== this.userShardInstanceId) {
         return;
@@ -431,6 +473,25 @@ export class FreenetConnection {
       const threadRoot = notifId ? this.threadInstanceToRoot.get(notifId) : undefined;
       if (threadRoot) {
         this.refreshLikes(threadRoot);
+        return;
+      }
+      // Global-index update (a post was shared to the public timeline): the
+      // delta is the externally-tagged `GlobalIndexDelta::Posts` (`{"Posts":[…]}`)
+      // — the SAME wire shape as the user-shard Posts delta — so parse it the
+      // same way and emit each (top-level) post live.
+      if (this.globalIndexInstanceId !== null && notifId === this.globalIndexInstanceId) {
+        const updateData = notification.update as UpdateData;
+        if (!updateData || updateData.updateDataType !== UpdateDataType.DeltaUpdate) return;
+        const delta = updateData.updateData as { delta: number[] } | null;
+        if (!delta) return;
+        const deltaJson = new TextDecoder("utf8").decode(Uint8Array.from(delta.delta));
+        const parsed = JSON.parse(deltaJson.replace(/\x00/g, "")) as {
+          Posts?: ContractPost[];
+        };
+        for (const cp of parsed.Posts ?? []) {
+          if (cp.reply_to) continue; // top-level public timeline only
+          this.callbacks.onNewGlobalPost?.(contractPostToUiPost(cp));
+        }
         return;
       }
       // The only other update source is the owner's user shard.
@@ -692,7 +753,47 @@ export class FreenetConnection {
     // Empty parameters → the singleton instance.
     const key = deriveShardContractKey(codeHash, new Uint8Array(0));
     this.globalIndexKey = key;
+    // Record the instance id so handleGetResponse / handleUpdateNotification can
+    // route the singleton's read + live-update responses (mirrors the user shard).
+    this.globalIndexInstanceId = key.encode();
     return key;
+  }
+
+  /**
+   * Read the public-timeline snapshot from the global index. Mirrors
+   * {@link loadState} but targets the singleton index key. Unlike a write
+   * (share), a reader MUST NOT instantiate the singleton — so there is no
+   * GET-probe/PUT here: an absent index simply rejects the GET and the timeline
+   * stays empty. No-ops when the key cannot be derived (offline / dev build).
+   */
+  loadGlobalIndex(): void {
+    const key = this.globalIndexKeyOrNull();
+    if (!this.api || !key) return;
+    // Signal that the read path actually issued a GET against the singleton.
+    // This fires whether or not the index is instantiated yet (a fresh network
+    // has no index, so the GET rejects and onGlobalPostsLoaded never fires) —
+    // so it is the reliable "read path ran on a live node" marker, distinct from
+    // the "[freenet] Loaded N …" success log emitted only on a populated index.
+    console.log("[global-index] loading public timeline");
+    this.serializedGet(new GetRequest(key, true)).catch((e) =>
+      console.error("[global-index] get failed:", e),
+    );
+    // Mirror the user-shard flow (loadUserShard + subscribeUserShard): a reader
+    // also subscribes so subsequently-shared posts arrive live as deltas.
+    this.subscribeGlobalIndex();
+  }
+
+  /**
+   * Subscribe to the global index so shared posts arrive live as
+   * {@link handleUpdateNotification} deltas. Mirrors {@link subscribeUserShard};
+   * no-ops when the key cannot be derived (offline / dev build).
+   */
+  private subscribeGlobalIndex(): void {
+    const key = this.globalIndexKeyOrNull();
+    if (!this.api || !key) return;
+    this.api
+      .subscribe(new SubscribeRequest(key, []))
+      .catch((e) => console.error("[global-index] subscribe failed:", e));
   }
 
   /** Fetch the bundled raw global-index-shard WASM bytes (served at dist root). */

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -5,6 +5,7 @@ import { createApp } from "./app";
 import { FreenetConnection, type LikeState, type RepostState, type QuoteState } from "./freenet-api";
 import { Post } from "./types";
 import { createOnboarding } from "./components/onboarding";
+import { createPostCard } from "./components/post-card";
 import {
   getIdentity,
   createIdentity,
@@ -44,9 +45,25 @@ const appRoot = document.getElementById("app")!;
 // ---------------------------------------------------------------------------
 let localPosts: Post[] = [];
 const knownPostIds = new Set<string>();
+// Public-timeline (global-index) buffer. Independent of identity: it feeds the
+// logged-out landing feed AND the logged-in Home → Discover tab. Mirrors the
+// localPosts / knownPostIds pair above.
+let globalPosts: Post[] = [];
+const globalPostIds = new Set<string>();
 let appElement: HTMLElement | null = null;
+// The read-only public timeline mounted UNDER the onboarding overlay so a fresh
+// (logged-out) visitor lands on live network posts instead of a blank page.
+// Created lazily by showOnboarding(); torn down by renderApp() once identity is
+// known and the full app takes over.
+let landingElement: (HTMLElement & { updateGlobalPosts: (posts: Post[]) => void }) | null = null;
 let appRendered = false;
 let delegateTimeoutId: ReturnType<typeof setTimeout> | null = null;
+// onStatusChange("connected") fires on every WebSocket (re)open. The global
+// index read/subscribe must start exactly once — a reconnect re-issuing the GET
+// would re-run the snapshot merge (harmless now that it merges) and, worse,
+// re-subscribe to the singleton key. Mirror the user-shard's one-shot init
+// guard (userShardInitOwner) with a simple latch.
+let globalIndexStarted = false;
 
 // ---------------------------------------------------------------------------
 // Feed helpers
@@ -63,6 +80,49 @@ function refreshFeed(): void {
   (appElement as AppEl | null)?.updatePosts?.(localPosts);
 }
 
+// app.ts exposes updateGlobalPosts on the app element (the UI agent adds it) to
+// feed the Home → Discover tab. We forward defensively via optional-chaining so
+// this works regardless of whether that surface has landed yet. The same buffer
+// also drives the pre-auth landing feed when it is mounted.
+type GlobalAppEl = HTMLElement & { updateGlobalPosts?: (posts: Post[]) => void };
+
+function refreshGlobalFeed(): void {
+  (appElement as GlobalAppEl | null)?.updateGlobalPosts?.(globalPosts);
+  landingElement?.updateGlobalPosts(globalPosts);
+}
+
+// ---------------------------------------------------------------------------
+// Pre-auth landing feed (read-only public timeline)
+// ---------------------------------------------------------------------------
+// A minimal, read-only list of global-index posts shown behind the onboarding
+// overlay. Intentionally NOT the full createApp(): logged-out visitors have no
+// delegate/identity, so there is no compose/like/repost/quote — those actions
+// require signing. Mounting this into appRoot keeps the page from being blank
+// while the onboarding overlay (a separate document.body element) sits on top.
+function createLandingFeed(): HTMLElement & {
+  updateGlobalPosts: (posts: Post[]) => void;
+} {
+  const wrap = document.createElement("main");
+  wrap.className = "feed-column screen landing-feed";
+
+  const list = document.createElement("div");
+  // Reuse the in-app feed's styled list class so the landing list inherits the
+  // same spacing/borders (.feed-list has no SCSS rules; .feed__posts does).
+  list.className = "feed__posts";
+  wrap.appendChild(list);
+
+  const el = wrap as HTMLElement & {
+    updateGlobalPosts: (posts: Post[]) => void;
+  };
+  el.updateGlobalPosts = (posts: Post[]) => {
+    list.replaceChildren();
+    // Read-only: pass no callbacks so cards have no actionable affordances for
+    // a logged-out visitor.
+    for (const post of posts) list.appendChild(createPostCard(post));
+  };
+  return el;
+}
+
 // ---------------------------------------------------------------------------
 // Render the app (called once identity is known)
 // ---------------------------------------------------------------------------
@@ -74,6 +134,10 @@ function renderApp(identity: Identity): void {
   // Remove onboarding/splash if present
   document.querySelector(".onboarding-overlay")?.remove();
   document.querySelector(".splash-screen")?.remove();
+  // The full app replaces the read-only landing feed; drop it so we don't stack
+  // two feeds in appRoot.
+  landingElement?.remove();
+  landingElement = null;
 
   connection.setUser(identity.publicKey, identity.displayName, identity.handle);
 
@@ -121,6 +185,10 @@ function renderApp(identity: Identity): void {
 
   // Load posts now that app is rendered
   connection.loadState();
+  // Hand any already-buffered public-timeline posts to the app's Discover tab
+  // (they may have arrived while the landing feed was showing). Live updates
+  // continue to flow via refreshGlobalFeed().
+  refreshGlobalFeed();
 }
 
 // ---------------------------------------------------------------------------
@@ -161,10 +229,57 @@ const connection = new FreenetConnection({
     localPosts = [post, ...localPosts];
     refreshFeed();
   },
+  onGlobalPostsLoaded: (posts: Post[]) => {
+    console.log(`[freenet] Loaded ${posts.length} public-timeline posts`);
+    // MERGE, do not replace. The global index is multi-writer, and the
+    // subscribe fires right after the GET is queued — so a live delta
+    // (onNewGlobalPost) can land in globalPosts BEFORE this snapshot arrives.
+    // If the node served a state that predates that share, a blind
+    // `globalPosts = posts` would silently drop the just-seen post forever
+    // (its id also purged from the dedup set, so no later delta re-adds it).
+    // Keep any buffered post whose id is not in the snapshot, union, re-sort
+    // newest-first, and rebuild the dedup set from the union. (The user-shard
+    // loadState path overwrites safely only because the owner is the sole
+    // writer; the public firehose has no such guarantee.)
+    const snapshotIds = new Set(posts.map((p) => p.id));
+    const survivors = globalPosts.filter((p) => !snapshotIds.has(p.id));
+    globalPosts = [...posts, ...survivors].sort(
+      (a, b) => b.timestamp.getTime() - a.timestamp.getTime(),
+    );
+    globalPostIds.clear();
+    for (const post of globalPosts) globalPostIds.add(post.id);
+    refreshGlobalFeed();
+  },
+  onNewGlobalPost: (post: Post) => {
+    if (globalPostIds.has(post.id)) return;
+    globalPostIds.add(post.id);
+    // Insert then re-sort newest-first to preserve the buffer invariant the GET
+    // snapshot establishes. A live delta is normally the newest post (prepend
+    // alone would suffice), but the global index is multi-writer and deltas can
+    // arrive out of timestamp order — sorting keeps Discover/landing ordering
+    // correct regardless. (The single-writer user-shard onNewPost can prepend
+    // safely; the public firehose cannot assume monotonic arrival.)
+    globalPosts = [post, ...globalPosts].sort(
+      (a, b) => b.timestamp.getTime() - a.timestamp.getTime(),
+    );
+    refreshGlobalFeed();
+  },
   onStatusChange: (status) => {
     console.log(`[freenet] Status: ${status}`);
 
     if (status === "connected") {
+      // Start the public-timeline read path independent of identity, so even a
+      // logged-out visitor sees live network posts on the landing feed.
+      // loadGlobalIndex() also subscribes internally (load → subscribe, mirror
+      // of initUserShard). It is fire-and-forget (it swallows its own errors)
+      // and runs before the delegate wiring so it never blocks or races the
+      // identity flow. Guarded to once per page so a reconnect does not
+      // re-subscribe to the singleton key.
+      if (!globalIndexStarted) {
+        globalIndexStarted = true;
+        connection.loadGlobalIndex();
+      }
+
       // Wire delegate and request identity
       wireDelegateAndRequestIdentity();
     }
@@ -429,6 +544,16 @@ function showOnboarding(): void {
   if (appRendered) return;
   // Remove splash
   document.querySelector(".splash-screen")?.remove();
+
+  // Mount the read-only public timeline UNDER the overlay so the page isn't
+  // blank while logged out. The overlay (appended to document.body below) is a
+  // full-screen element that layers on top of appRoot. Seed it with whatever
+  // global posts have already arrived; refreshGlobalFeed() keeps it live.
+  if (!landingElement) {
+    landingElement = createLandingFeed();
+    appRoot.appendChild(landingElement);
+    landingElement.updateGlobalPosts(globalPosts);
+  }
 
   const onboarding = createOnboarding((displayName: string, secretKey?: string) => {
     const identity = createIdentity(displayName, secretKey);

--- a/web/tests/node-e2e/live-node.spec.ts
+++ b/web/tests/node-e2e/live-node.spec.ts
@@ -97,6 +97,41 @@ test("fresh delegate replies 'no identity' over the live API -> onboarding rende
   });
 });
 
+test("logged-out visitor: public timeline loads behind onboarding (live GET)", async ({
+  page,
+}) => {
+  // MUST run before "creating an identity" — once the shared delegate persists
+  // an identity, onboarding (and thus the landing feed) never shows again.
+  const { logs } = instrument(page);
+  await page.goto("", { waitUntil: "domcontentloaded" });
+  const a = app(page);
+
+  // Onboarding up (fresh delegate -> no identity) == logged-out.
+  await expect
+    .poll(() => logs.some((l) => l.includes("[identity] No identity in delegate — show onboarding")), {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+
+  // The read-only landing feed mounts UNDER the onboarding overlay so the page
+  // is never blank for a logged-out visitor. (Both live inside the app iframe.)
+  await expect(a.locator(".landing-feed")).toBeAttached({ timeout: 15_000 });
+  await expect(a.locator(".onboarding-overlay")).toBeVisible({ timeout: 10_000 });
+
+  // Live-only signal: loadGlobalIndex() derived the singleton key and issued a
+  // GET. This fires regardless of whether the index is instantiated — a FRESH
+  // node has no index, so the GET rejects and the "Loaded N …" success log never
+  // appears; asserting it would make the spec depend on a pre-populated index.
+  // The "loading public timeline" marker proves the read path is wired
+  // end-to-end (key derivation -> serialized GET) and cannot appear offline
+  // (offline mode never connects, never derives the key, never GETs).
+  await expect
+    .poll(() => logs.some((l) => l.includes("[global-index] loading public timeline")), {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+});
+
 test("creating an identity advances past onboarding to the app shell", async ({ page }) => {
   const { logs } = instrument(page);
   // goto("") navigates to baseURL verbatim. goto("/") would resolve to the
@@ -126,4 +161,128 @@ test("creating an identity advances past onboarding to the app shell", async ({ 
 
   await expect(a.locator(".onboarding-overlay")).toBeHidden({ timeout: 45_000 });
   await expect(a.locator("aside.sidebar")).toBeVisible({ timeout: 45_000 });
+});
+
+// --- Global-index public timeline (read/render side of #49) ----------------
+// These exercise the live read path: loadGlobalIndex() GETs the singleton over
+// the real node WS, the result feeds the pre-auth landing feed (logged-out) and
+// the Home -> Discover tab (logged-in). The decisive live-only signal is the
+// "[freenet] Loaded N public-timeline posts" console line — it only logs after a
+// real GET response from the node (offline mock never connects, never GETs).
+//
+// IMPORTANT — shared-node state: the config is serial (workers:1) against ONE
+// node + delegate, and the "creating an identity" spec persists an identity
+// that survives into later specs (the delegate then replies Identity, not "no
+// identity", so onboarding NEVER shows again). So:
+//  * the LOGGED-OUT landing-feed spec is placed BEFORE "creating an identity",
+//    the only point at which onboarding is guaranteed.
+//  * specs needing the LOGGED-IN app are order-independent via ensureAppShell():
+//    register IF onboarding is showing, otherwise the shell is already up from a
+//    prior spec's identity — proceed either way.
+
+/**
+ * Drive the app to the logged-in shell, tolerant of shared-node state. If the
+ * delegate has no identity yet, onboarding shows and we register; if a prior
+ * spec already created one, the shell is already up and we just wait for it.
+ * Returns the app FrameLocator with the sidebar visible.
+ */
+async function ensureAppShell(page: Page, displayName: string): Promise<FrameLocator> {
+  const a = app(page);
+  const onboarding = a.locator(".onboarding-overlay");
+  const sidebar = a.locator("aside.sidebar");
+  // Race: whichever the live delegate decided. Wait until ONE is present.
+  await expect
+    .poll(async () => (await onboarding.count()) > 0 || (await sidebar.count()) > 0, {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+  if ((await onboarding.count()) > 0 && (await sidebar.count()) === 0) {
+    await a.locator(".onboarding-input").first().fill(displayName);
+    const join = a.locator(".onboarding-btn", { hasText: "Join" });
+    await expect(join).toBeEnabled({ timeout: 10_000 });
+    await join.click();
+  }
+  await expect(sidebar).toBeVisible({ timeout: 45_000 });
+  return a;
+}
+
+test("logged-in: Home -> Discover tab renders the global index (not the old stub)", async ({
+  page,
+}) => {
+  await page.goto("", { waitUntil: "domcontentloaded" });
+  const a = await ensureAppShell(page, "Discover Tester");
+
+  // Switch to the Discover tab — previously a dead "Discover is quiet right now"
+  // stub; now it renders the global-index read path.
+  const discoverTab = a.locator(".feed-tab", { hasText: "Discover" });
+  await expect(discoverTab).toBeVisible({ timeout: 10_000 });
+  await discoverTab.click();
+
+  // The old stub copy must be GONE (proves the stub branch was replaced).
+  await expect(a.locator(".feed__posts")).not.toContainText("Discover is quiet right now", {
+    timeout: 10_000,
+  });
+  // With a fresh/near-empty index the read path renders either the new empty
+  // note or real post cards — both prove the wired render, never the old stub.
+  await expect
+    .poll(
+      async () => {
+        const empty = await a.locator(".feed__posts .following-note__title").count();
+        const cards = await a.locator(".feed__posts .post").count();
+        return empty > 0 || cards > 0;
+      },
+      { timeout: 15_000 },
+    )
+    .toBeTruthy();
+});
+
+// SKIPPED — deferred to the #50 contract-persistence tier. This is the full
+// write->index->read round-trip: compose with "share to public timeline" ON,
+// then read the post back out of the global index. It does not pass reliably on
+// a single live node in this slice: the share UPDATE instantiates the singleton
+// on first write, but the post is not observable via a subsequent GET within a
+// generous window — the same uninstantiated-singleton / subscribe-before-PUT /
+// single-node propagation seam #50 tracks (delegate-persistence and
+// GET-on-uninstantiated are the sibling unknowns). The read/render path itself
+// is proven by the two specs above (landing-feed live GET signal + Discover-tab
+// render). Kept (not deleted) so it activates once #50 lands the contract tier.
+test.skip("round-trip: a shared post reaches the Discover timeline", async ({ page }) => {
+  // register (or reuse the shared identity) -> compose with the public-timeline
+  // toggle ON -> reload -> the post should surface in the Discover tab.
+  await page.goto("", { waitUntil: "domcontentloaded" });
+  const a = await ensureAppShell(page, "RoundTrip Tester");
+
+  // Compose a post with a UNIQUE marker (re-runs share the node, so a fixed
+  // string could already be present from a prior run; the timestamp keeps it
+  // distinct enough for this run's assertion) and tick "Share to public timeline".
+  const marker = `e2e-roundtrip-${Date.now()}`;
+  await a.locator(".quickpost").click();
+  await expect(a.locator(".compose-modal-overlay")).toBeVisible({ timeout: 10_000 });
+  await a.locator(".compose-modal__textarea").fill(marker);
+  await a.locator(".compose-modal__share-check").check();
+  const postBtn = a.locator(".compose-modal__post");
+  await expect(postBtn).toBeEnabled({ timeout: 10_000 });
+  await postBtn.click();
+  await expect(a.locator(".compose-modal-overlay")).toBeHidden({ timeout: 15_000 });
+
+  // The post lands on the owner's user shard immediately (Following). The share
+  // to the global index is fire-and-forget and instantiates the singleton on
+  // first write. Rather than depend on a live subscription delivering the delta
+  // BEFORE the index existed (subscribe ran pre-instantiation — that
+  // delivery-after-instantiate seam is the deferred #50 tier), reload the page:
+  // a fresh boot re-derives the key and re-GETs the now-populated index
+  // deterministically, exercising this PR's read/render path against real data.
+  // Allow brief propagation for the share UPDATE to commit before reloading.
+  await page.waitForTimeout(5_000);
+  await page.reload({ waitUntil: "domcontentloaded" });
+  const a2 = await ensureAppShell(page, "RoundTrip Tester");
+  const discoverTab = a2.locator(".feed-tab", { hasText: "Discover" });
+  await expect(discoverTab).toBeVisible({ timeout: 30_000 });
+  await discoverTab.click();
+  await expect
+    .poll(async () => a2.locator(".feed__posts").getByText(marker).count(), {
+      timeout: 60_000,
+      message: "shared post did not surface in the Discover timeline after reload",
+    })
+    .toBeGreaterThan(0);
 });


### PR DESCRIPTION
## What

Wires the **read/render side** of the global-index public-timeline contract. PR #49 shipped the write side (opt-in "share to public timeline"); this makes those posts visible.

Follows the conventional social-app shape the project chose:
- **Logged-out** visitors land on the public timeline (read-only feed behind the onboarding overlay) — no more blank page for a fresh user.
- **Logged-in** users get the timeline in the Home feed's **Discover** tab (previously a dead "Discover is quiet right now" stub).

## How

**`freenet-api.ts`**
- `loadGlobalIndex()` + `subscribeGlobalIndex()`: GET the singleton index, subscribe for live deltas. A reader **never instantiates** the singleton (no ensure/PUT) — an absent index just yields an empty timeline.
- GET routing parses the singleton's `{"posts":{id:Post}}` **MAP** (Rust `BTreeMap`, not a Vec), filters to top-level posts, sorts newest-first; live `{"Posts":[…]}` deltas route to `onNewGlobalPost`.
- New optional callbacks `onGlobalPostsLoaded` / `onNewGlobalPost`; `globalIndexInstanceId` for response routing.

**`index.ts`**
- Public-timeline buffer + read-only landing feed mounted behind onboarding.
- `onGlobalPostsLoaded` **merges** the snapshot with already-buffered live deltas — the global index is multi-writer, so a blind replace could permanently drop a delta that arrived before the GET resolved (caught in review). `onNewGlobalPost` re-sorts.
- One-shot guard so a WS reconnect doesn't re-subscribe the singleton.

**`feed.ts` / `app.ts`**
- Discover tab renders the global index (replaces the stub); app exposes `updateGlobalPosts` → `feed.updateDiscoverPosts`.

## Tests

- **vitest**: +6 read-path tests — map parse, empty index, reply filter, live delta, routing isolation (global GET must not fire the user-shard callback and vice-versa), offline no-op.
- **node-e2e** (live Freenet node, `cargo make test-ui-node-e2e`): new specs for the **logged-out landing feed** (asserts the `[global-index] loading public timeline` live read-path signal — only emittable against a real node) and the **logged-in Discover render** (old stub gone). **6 passed / 1 skipped** against a booted node.
- The full write→index→read **round-trip is `test.skip`'d** pending the #50 contract-persistence tier: the uninstantiated-singleton / subscribe-before-PUT / single-node propagation seam is not reliably observable on one live node. Kept (not deleted) so it activates when #50 lands.

## Scope

**UI-only — no contract (Rust) changes.** Gates green locally: `fmt-check`, `clippy -D warnings`, `tsc` (strict), vitest (36), node-e2e (6 passed / 1 skipped).

## Provenance

Implemented via a 6-phase multi-agent workflow (scout → API layer → wiring+UI → tests → gate → adversarial review panel). The review panel's one `fix-needed` (snapshot-clobbers-delta race) and the nits were fixed before commit.

Follow-up to #49. Deeper deferred items tracked in #50.