### PR TITLE
fix(release): publish identity delegate to prod + sidebar version marker

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -488,6 +488,13 @@ echo "────────────────────────�
 description = "End-to-end PRODUCTION publish (use scripts/release.sh, not directly)"
 dependencies = [
     "build",
+    # Register the identity delegate on the production node. The delegate key
+    # the webapp targets is derived deterministically from the delegate wasm
+    # code hash, so re-registering each release is idempotent (same delegate
+    # id, identities preserved). WITHOUT this the live node has no delegate:
+    # GetIdentity/CreateIdentity get no reply, the app falls back to
+    # "Anonymous" and posts can never be signed (see PR fixing this).
+    "publish-identity",
     "update-published-contract-prod",
     "publish-webapp",
 ]

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -17,6 +17,11 @@
 
   let { onNavigate, onCompose, activeView, notifCount = 0 }: Props = $props();
 
+  // Build version baked at compile time from the git tag (see vite.config.ts).
+  // Shown bottom-left so a stale published-contract is visible at a glance.
+  const APP_VERSION: string =
+    typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "dev";
+
   const ICON_HOME = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
   <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
   <polyline points="9 22 9 12 15 12 15 22"/>
@@ -169,6 +174,9 @@
     </div>
     <div class="sidebar-status__row">
       <span class="live-dot live-dot--static"></span><span>{keyText}</span>
+    </div>
+    <div class="sidebar-status__row sidebar-status__version" title="Webapp build version">
+      <span>{APP_VERSION}</span>
     </div>
   </div>
 </aside>

--- a/web/src/scss/_sidebar.scss
+++ b/web/src/scss/_sidebar.scss
@@ -258,6 +258,12 @@
   color: var(--ink-3);
 }
 
+.sidebar-status__version {
+  color: var(--ink-4, var(--ink-3));
+  opacity: 0.65;
+  padding-left: 21px; // align text with the dotted rows above
+}
+
 .live-dot {
   width: 5px;
   height: 5px;

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -7,3 +7,4 @@ declare const __DELEGATE_KEY__: string;
 declare const __DELEGATE_KEY_BYTES__: number[];
 declare const __DELEGATE_CODE_HASH_BYTES__: number[];
 declare const __OFFLINE_MODE__: boolean;
+declare const __APP_VERSION__: string;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,11 +2,31 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { readFileSync, existsSync } from "fs";
+import { execSync } from "child_process";
 import { resolve } from "path";
 
 function readFileOrDefault(filename: string, fallback: string): string {
   const filePath = resolve(__dirname, filename);
   return existsSync(filePath) ? readFileSync(filePath, "utf-8").trim() : fallback;
+}
+
+// Build version shown in the sidebar (mirrors freenet-email's version chip).
+// Source of truth is the latest git tag (releases are tagged vX.Y.Z); falls
+// back to the short commit hash, then "dev". A visible version stops us
+// chasing ghost bugs from a stale published-contract on one side.
+function buildVersion(): string {
+  const env = process.env.APP_VERSION;
+  if (env) return env.startsWith("v") ? env : `v${env}`;
+  try {
+    return execSync("git describe --tags --always --dirty", {
+      cwd: __dirname,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "dev";
+  }
 }
 
 export default defineConfig({
@@ -19,6 +39,7 @@ export default defineConfig({
     __DELEGATE_KEY_BYTES__: readFileOrDefault("delegate_key_bytes.json", "[]"),
     __DELEGATE_CODE_HASH_BYTES__: readFileOrDefault("delegate_code_hash_bytes.json", "[]"),
     __OFFLINE_MODE__: JSON.stringify(process.env.VITE_OFFLINE_MODE === "1"),
+    __APP_VERSION__: JSON.stringify(buildVersion()),
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
## Symptom

Logged in, picked a display name, created a post with "Share to public timeline" — but the app showed **"Anonymous"** and nothing ever appeared in the public timeline. Console showed the delegate request timing out:

```
[identity] Delegate wired (key: 32b, code_hash: 32b)
[identity] Delegate timeout — showing onboarding
```

## Root cause

**The identity delegate was never published to the live production node.**

`cargo make publish-production` depended on `build` + `update-published-contract-prod` + `publish-webapp` — but **not** `publish-identity`. Only the test tier (`publish-all`) registered the delegate. So on the production node:

- boot-time `GetIdentity` → delegate → no reply → 5s timeout → "Anonymous"
- onboarding `CreateIdentity` → no reply → no real ML-DSA-65 identity
- without a signing identity, posts can't be signed → nothing persists

This is **distinct from** the field-8 flatbuffer shard-PUT bug fixed earlier (#56). Both defects sat on the browser write path; both had to be fixed for it to work end-to-end. The earlier fix made the shard PUTs serialize; this one makes the node actually have a delegate to answer identity requests.

## Fix

- **`Makefile.toml`**: add `publish-identity` to `publish-production` deps. The delegate key the webapp targets is derived deterministically from the delegate wasm code hash, so re-registering on every release is idempotent — same delegate id, stored identities preserved.
- **Version marker** (mirrors freenet-email's version chip): a muted `vX.Y.Z` bottom-left in the sidebar, baked at build time from `git describe --tags` via a new `__APP_VERSION__` Vite define (overridable with the `APP_VERSION` env var). Makes a stale published-contract obvious at a glance — exactly the kind of ghost-bug this PR chased.

## Verification

Reproduced + fixed live against the production node (`127.0.0.1:7509`):

1. Before: every load → `Delegate timeout — showing onboarding`, "Anonymous".
2. Published the delegate manually (`WS_API_PORT=7509 fdev publish … delegate`) → key `7yYDcBo6RaiZf5tksz1QxVsi4rw4RqAEewZE7RWz2ypq`, matches the webapp's baked `__DELEGATE_KEY__`.
3. After: delegate replies instantly. Onboarded "CavemanTest" →
   - `[delegate] Response: {type: Identity, public_key: f26a181c…, display_name: CavemanTest}`
   - `[user-shard] PUT instantiating shard`
   - `[delegate] Response: {type: Signed, post_id: e9c6f926…}`
   - `[freenet] Post published`
   - `[freenet] Loaded 1 posts from network`
   - `[freenet] Loaded 1 public-timeline posts` ← shows in Discover

ML-DSA-65 keygen on a cold single node is slow (~30s for CreateIdentity, ~100s post-to-Discover) but correct.

- `svelte-check`: 0 errors
- `vitest`: 40/40
- `build:offline`: green
- version chip verified rendering (`v0.1.2-dirty` on this branch; the release tag on a clean build)

## Note

The production node already has the delegate published (done manually during this investigation), so the live app works **now**. This PR makes it permanent so the next release doesn't regress.
