### PR TITLE
fix(release): pin sidebar version chip to the release tag

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -70,6 +70,12 @@ WEBAPP_VERSION=$(( MAJ * 1000000 + MIN * 1000 + PAT ))
 [ "$WEBAPP_VERSION" -gt 0 ] || die "packed version must be > 0 (got $WEBAPP_VERSION for $VERSION)"
 export WEBAPP_VERSION
 
+# Pin the sidebar version chip (web/vite.config.ts reads APP_VERSION) to the
+# release tag. Without this the webapp builds BEFORE the git tag is created, so
+# `git describe` bakes a stale `vPREV-N-gHASH` string instead of the clean
+# `vX.Y.Z` we're releasing.
+export APP_VERSION="$TAG"
+
 # ─── 1. Preflight ──────────────────────────────────────────────────────────────
 echo "── preflight ─────────────────────────────────────────────────────────────"
 


### PR DESCRIPTION
## Problem

v0.1.3 shipped with the sidebar version chip reading **`v0.1.2-1-g589accc`** instead of `v0.1.3`.

`scripts/release.sh` runs `cargo make publish-production` (which builds the webapp) **before** it creates the git tag. So `vite.config.ts`'s `git describe --tags` saw HEAD as "1 commit past v0.1.2" and baked that string in.

## Fix

Export `APP_VERSION="$TAG"` before the build. `web/vite.config.ts` already honors the `APP_VERSION` env override (added in #57), so the chip now pins to the exact release tag.

## Impact

Cosmetic-only; takes effect on the next release. The on-chain signed version (1003 for v0.1.3) was always correct — only the displayed string was stale. v0.1.3's chip stays `v0.1.2-1-g589accc` unless re-cut as v0.1.4.

Verified: `export APP_VERSION=v0.1.4; npm run build:offline` bakes `v0.1.4` into the bundle.