### PR TITLE
feat(replies): wire reply compose end-to-end + node-e2e (#12)

### DIFF
--- a/delegates/identity/src/lib.rs
+++ b/delegates/identity/src/lib.rs
@@ -72,6 +72,28 @@ enum Request {
         root_post_id: String,
         quote_post_id: String,
     },
+    /// Sign a reply post for a thread. The delegate builds a canonical [`Post`]
+    /// with `reply_to` populated (binding the reply to its parent thread root),
+    /// derives the content-addressed id, and signs the payload. `reply_to` is
+    /// the content-addressed id of the root post (the thread shard key);
+    /// `quoted_post` is the content-addressed id of an additionally quoted post
+    /// (empty for a plain reply). `nonce` is echoed so the UI can match the
+    /// response to its pending draft. SignPost is kept byte-identical (empty
+    /// `reply_to`) so existing top-level post signatures are unaffected.
+    SignReply {
+        nonce: String,
+        content: String,
+        author_name: String,
+        author_handle: String,
+        timestamp: u64,
+        /// Content-addressed id of the root post this is a reply to (required,
+        /// non-empty — the contract's `reply_is_acceptable` rejects empty).
+        reply_to: String,
+        /// Content-addressed id of the quoted post, if this reply also quotes
+        /// another post; empty/absent for a plain reply.
+        #[serde(default)]
+        quoted_post: String,
+    },
     /// Export the secret seed for backup/migration.
     ExportIdentity,
     /// Import a secret seed + identity from another device.
@@ -127,6 +149,18 @@ enum Response {
         signer_pubkey: String, // hex-encoded VK
         quote_post_id: String,
         signature: String, // hex-encoded ML-DSA-65 signature
+    },
+    /// A signed reply [`Post`] ready to submit to the user shard (and the
+    /// thread shard via `ThreadDelta::Replies`). `nonce` is echoed; `post_id`,
+    /// `signature`, and `public_key` mirror the `Signed` response so the UI
+    /// can assemble and PUT the post without special-casing. Kept as a
+    /// distinct variant (rather than reusing `Signed`) so the UI can
+    /// distinguish a reply response from a top-level post response.
+    SignedReply {
+        nonce: String,      // echoed so the UI can match its pending draft
+        post_id: String,    // content-addressed id = blake3(signing payload)
+        signature: String,  // hex-encoded ML-DSA-65 signature (3309 bytes)
+        public_key: String, // hex-encoded VK
     },
     ExportedIdentity {
         secret_key: String, // hex-encoded 32-byte secret seed
@@ -203,6 +237,45 @@ fn build_signed_post(
         // A quote repost carries the quoted post's content address here; empty
         // for an ordinary post, keeping the signing payload byte-identical to the
         // pre-quoted_post shape.
+        quoted_post: quoted_post.to_string(),
+        signature: None,
+    };
+    post.id = post.compute_id();
+    let signature: ml_dsa::Signature<MlDsa65> = signing_key.sign(&post.signing_payload());
+    post.signature = Some(hex::encode(signature.encode()));
+    post
+}
+
+/// Assemble the canonical reply [`Post`] and sign it with `signing_key`.
+///
+/// Mirrors [`build_signed_post`] but populates `reply_to` (and optionally
+/// `quoted_post`) so the signing payload binds the thread root. The reply
+/// is structurally identical to a post — it lives on the user shard — but
+/// `reply_to` being non-empty means `Post::signing_payload` appends it,
+/// making the id/signature different from a same-content top-level post.
+/// This keeps `SignPost` byte-identical (empty `reply_to`).
+/// Pure (no `ctx` / secret store) so it is unit-testable on the host target.
+fn build_signed_reply(
+    signing_key: &MlDsaSigningKey<MlDsa65>,
+    content: &str,
+    author_name: &str,
+    author_handle: &str,
+    timestamp: u64,
+    reply_to: &str,
+    quoted_post: &str,
+) -> Post {
+    let public_key = vk_hex(signing_key);
+    let mut post = Post {
+        id: String::new(),
+        author_pubkey: public_key,
+        author_name: author_name.to_string(),
+        author_handle: author_handle.to_string(),
+        content: content.to_string(),
+        timestamp,
+        // Non-empty reply_to: mixed into the signing payload so this reply is
+        // thread-bound and cannot be retargeted to a different root.
+        reply_to: reply_to.to_string(),
+        // Optional: non-empty when this reply also quotes another post.
         quoted_post: quoted_post.to_string(),
         signature: None,
     };
@@ -341,6 +414,24 @@ impl DelegateInterface for IdentityDelegate {
                         root_post_id,
                         quote_post_id,
                     } => sign_quote_ref(ctx, &nonce, &root_post_id, &quote_post_id),
+                    Request::SignReply {
+                        nonce,
+                        content,
+                        author_name,
+                        author_handle,
+                        timestamp,
+                        reply_to,
+                        quoted_post,
+                    } => sign_reply(
+                        ctx,
+                        &nonce,
+                        &content,
+                        &author_name,
+                        &author_handle,
+                        timestamp,
+                        &reply_to,
+                        &quoted_post,
+                    ),
                     Request::ExportIdentity => export_identity(ctx),
                     Request::ImportIdentity {
                         secret_key,
@@ -563,6 +654,52 @@ fn sign_quote_ref(
         signer_pubkey: record.signer_pubkey,
         quote_post_id: quote_post_id.to_string(),
         signature,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sign_reply(
+    ctx: &DelegateCtx,
+    nonce: &str,
+    content: &str,
+    author_name: &str,
+    author_handle: &str,
+    timestamp: u64,
+    reply_to: &str,
+    quoted_post: &str,
+) -> Response {
+    let signing_key = match load_signing_key(ctx) {
+        Ok(k) => k,
+        // Re-tag the load error with this request's nonce so the UI can drop
+        // exactly the stranded pending draft.
+        Err(Response::Error { message, .. }) => {
+            return Response::Error {
+                message,
+                nonce: Some(nonce.to_string()),
+            };
+        }
+        Err(resp) => return resp,
+    };
+
+    // Build + sign the canonical reply with the single trusted encoder
+    // (`common::post`) — the exact bytes the user-shard contract verifies.
+    // reply_to (non-empty) is mixed into the signing payload via
+    // `Post::signing_payload`, binding this reply to its thread root.
+    let post = build_signed_reply(
+        &signing_key,
+        content,
+        author_name,
+        author_handle,
+        timestamp,
+        reply_to,
+        quoted_post,
+    );
+
+    Response::SignedReply {
+        nonce: nonce.to_string(),
+        post_id: post.id,
+        signature: post.signature.unwrap_or_default(),
+        public_key: post.author_pubkey,
     }
 }
 
@@ -965,5 +1102,136 @@ mod test {
         // Distinct domain tags (raven:post:v1 vs raven:thread-like:v1) guarantee
         // the byte payloads differ.
         assert_ne!(post.signing_payload(), like.signing_payload("root"));
+    }
+
+    // -- SignReply tests --
+
+    // R1. build_signed_reply output verifies under Post::verify() — the same
+    //     code path the user-shard contract runs. Confirms reply_to is present
+    //     and the signing payload / id are consistent with what the verifier
+    //     expects.
+    #[test]
+    fn signed_reply_verifies_under_common() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let reply = build_signed_reply(
+            &sk,
+            "nice post",
+            "Bob",
+            "@bob",
+            1_700_000_000_001,
+            "root_post_id_aaaaaa",
+            "",
+        );
+
+        assert_eq!(reply.verify(), Ok(()));
+        assert_eq!(reply.author_pubkey, vk_hex(&sk));
+        assert_eq!(reply.reply_to, "root_post_id_aaaaaa");
+        assert!(reply.quoted_post.is_empty());
+        assert!(reply.id_is_valid());
+        assert!(reply.signature.is_some());
+    }
+
+    // R2. A reply signed for root A fails verification when reply_to is swapped
+    //     to root B (rebinding guard). Changing reply_to changes the signing
+    //     payload, so the id no longer matches — a misfiled reply is detectable.
+    #[test]
+    fn signed_reply_rebinding_breaks_verification() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let reply = build_signed_reply(
+            &sk,
+            "nice post",
+            "Bob",
+            "@bob",
+            1_700_000_000_001,
+            "root_post_id_aaaaaa",
+            "",
+        );
+        assert_eq!(reply.verify(), Ok(()));
+
+        // Swap reply_to to a different root — id should no longer match.
+        let mut moved = reply.clone();
+        moved.reply_to = "root_post_id_bbbbbb".into();
+        // id is over the payload which includes reply_to, so id mismatch fires
+        // before the signature check.
+        assert_eq!(moved.verify(), Err(PostVerifyError::IdMismatch));
+
+        // Fix up the id but keep the original signature — now the signature
+        // must fail (the bytes that were signed no longer match).
+        moved.id = moved.compute_id();
+        assert_eq!(moved.verify(), Err(PostVerifyError::SignatureInvalid));
+    }
+
+    // R3a. A reply+quote (both reply_to and quoted_post non-empty) produces the
+    //      correct byte order in the signing payload: reply_to is appended first,
+    //      then quoted_post (as specified by Post::signing_payload). Verify both
+    //      that the assembled post verifies and that the payload bytes match the
+    //      hand-constructed expected order.
+    #[test]
+    fn signed_reply_and_quote_payload_byte_order() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let reply = build_signed_reply(
+            &sk,
+            "great and also replying",
+            "Alice",
+            "@alice",
+            1_700_000_000_002,
+            "reply_root_id",
+            "quoted_post_id",
+        );
+
+        // Full verification passes.
+        assert_eq!(reply.verify(), Ok(()));
+        assert_eq!(reply.reply_to, "reply_root_id");
+        assert_eq!(reply.quoted_post, "quoted_post_id");
+
+        // Manually reconstruct the expected payload to pin the field order:
+        // domain tag, author_pubkey, author_name, author_handle, content,
+        // timestamp (LE u64), reply_to (non-empty → appended), quoted_post
+        // (non-empty → appended after reply_to). Use the same length-prefix
+        // encoding Post::signing_payload uses.
+        fn put(buf: &mut Vec<u8>, field: &[u8]) {
+            buf.extend_from_slice(&(field.len() as u32).to_le_bytes());
+            buf.extend_from_slice(field);
+        }
+        let mut expected = Vec::new();
+        put(
+            &mut expected,
+            freenet_microblogging_common::post::POST_DOMAIN_TAG,
+        );
+        put(&mut expected, reply.author_pubkey.as_bytes());
+        put(&mut expected, b"Alice");
+        put(&mut expected, b"@alice");
+        put(&mut expected, b"great and also replying");
+        put(&mut expected, &1_700_000_000_002u64.to_le_bytes());
+        put(&mut expected, b"reply_root_id"); // reply_to first
+        put(&mut expected, b"quoted_post_id"); // quoted_post second
+
+        assert_eq!(reply.signing_payload(), expected);
+    }
+
+    // R3b. SignPost path is byte-identical: a post built with build_signed_post
+    //      (empty reply_to) and a reply built with build_signed_reply for the
+    //      same content have DIFFERENT signing payloads (reply_to being non-empty
+    //      extends the payload). Ensures the two paths do not collide.
+    #[test]
+    fn top_level_post_and_reply_have_different_payloads() {
+        let sk = signing_key_from_seed(&SEED_A);
+        let top_post = build_signed_post(&sk, "same content", "Alice", "@alice", 1_000, "");
+        let reply = build_signed_reply(
+            &sk,
+            "same content",
+            "Alice",
+            "@alice",
+            1_000,
+            "some_root_id",
+            "",
+        );
+
+        // Different payloads → different ids and different signatures.
+        assert_ne!(top_post.signing_payload(), reply.signing_payload());
+        assert_ne!(top_post.id, reply.id);
+        // Both still verify independently.
+        assert_eq!(top_post.verify(), Ok(()));
+        assert_eq!(reply.verify(), Ok(()));
     }
 }

--- a/scripts/node-e2e.sh
+++ b/scripts/node-e2e.sh
@@ -108,4 +108,7 @@ echo "── running node-e2e Playwright specs ──"
 cd "$ROOT/web/tests"
 proj_args=()
 [ -n "${PLAYWRIGHT_PROJECT:-}" ] && proj_args=(--project="$PLAYWRIGHT_PROJECT")
-BASE_URL="$APP_URL" npx playwright test --config=playwright.node.config.ts "${proj_args[@]}"
+# PLAYWRIGHT_GREP limits to specs/titles matching a substring (default: all).
+grep_args=()
+[ -n "${PLAYWRIGHT_GREP:-}" ] && grep_args=(--grep="$PLAYWRIGHT_GREP")
+BASE_URL="$APP_URL" npx playwright test --config=playwright.node.config.ts "${proj_args[@]}" "${grep_args[@]}"

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300;1,9..144,400&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&family=Geist+Mono:wght@300;400;500&display=swap"
     />
-    <!-- <title> is set at runtime in src/index.ts using APP_NAME
+    <!-- <title> is set at runtime in src/main.ts using APP_NAME
          from src/branding.ts (sourced from branding/app.json). -->
     <title></title>
     <!-- Apply OS theme preference synchronously to avoid FOUC. Freenet
@@ -21,8 +21,8 @@
         document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
       })();
     </script>
-    <script type="module" crossorigin src="./assets/index-TG1ep5FG.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-CLW3CEFO.css">
+    <script type="module" crossorigin src="./assets/index-CbFmjb0i.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-CWOlmsDo.css">
   </head>
   <body>
     <div id="app"></div>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -15,11 +15,14 @@
     identity,
     posts,
     globalPosts,
+    threadReplies,
     keyExportSecret,
     publish,
     like,
     repost,
     quote,
+    reply,
+    loadThreadReplies,
     completeOnboarding,
   } from "./stores/freenet";
   import type { Post } from "./types";
@@ -51,11 +54,12 @@
   // and passed it through to Feed/PostCard for the following-note affordances.
   const followedPubkeys = new Set<string>();
 
-  // Thread replies: app.ts openThread surfaced the posts that quote the root.
-  let threadReplies = $derived(
-    threadRoot
-      ? $posts.filter((p) => p.quotedPostId === threadRoot!.id)
-      : [],
+  // Thread replies: sourced from the thread-shard replies store (keyed by root
+  // post id), which is populated by onRepliesUpdated whenever the thread shard
+  // is read (on like/repost/subscribe). NOT the feed posts list — replies live
+  // in the thread shard, not in the owner's user shard.
+  let currentThreadReplies = $derived(
+    threadRoot ? ($threadReplies.get(threadRoot.id) ?? []) : [],
   );
 
   // My posts for the profile view (app.ts navigate "profile" logic).
@@ -81,13 +85,13 @@
 
   function openThread(post: Post): void {
     threadRoot = post;
+    // Eagerly fetch the thread shard so replies are visible on first open
+    // (before any engagement action has been taken on this session).
+    loadThreadReplies(post.id);
   }
 
-  // app.ts wired Thread's reply callback as `cb.reply?.(...)`, but index.ts
-  // never supplied a `reply` callback to createApp — so replies were a no-op
-  // until the #12 backend lands. Preserve that exact behavior here.
-  function onThreadReply(_rootPostId: string, _content: string): void {
-    // intentionally no-op (reply backend not yet wired)
+  function onThreadReply(rootPostId: string, content: string): void {
+    reply(rootPostId, content);
   }
 
   // ---- Compose ----
@@ -141,7 +145,7 @@
       {#if threadRoot}
         <Thread
           root={threadRoot}
-          replies={threadReplies}
+          replies={currentThreadReplies}
           onBack={() => (threadRoot = null)}
           onReply={onThreadReply}
         />

--- a/web/src/freenet-api.ts
+++ b/web/src/freenet-api.ts
@@ -36,7 +36,7 @@ import {
   shardContractKeyTFromParts,
   hexToBytes,
 } from "./shard-key";
-import { signPost, signLike, signRepost, signQuoteRef } from "./identity";
+import { signPost, signLike, signRepost, signQuoteRef, signReply } from "./identity";
 
 /**
  * Assemble the `PutRequest` that instantiates a parameterized shard contract.
@@ -208,6 +208,16 @@ interface PendingQuoteRef {
   quotePostId: string;
 }
 
+/** A pending reply awaiting the delegate's `Signed` response, keyed by nonce. */
+interface PendingReply {
+  nonce: string;
+  rootPostId: string;
+  author_name: string;
+  author_handle: string;
+  content: string;
+  timestamp: number;
+}
+
 /** Aggregate quote state for one post, derived from its thread shard. */
 export interface QuoteState {
   postId: string;
@@ -233,6 +243,7 @@ function contractPostToUiPost(cp: ContractPost): Post {
     reposted: false,
     quotes: 0,
     quotedPostId: cp.quoted_post && cp.quoted_post.length > 0 ? cp.quoted_post : undefined,
+    replyToId: cp.reply_to && cp.reply_to.length > 0 ? cp.reply_to : undefined,
   };
 }
 
@@ -268,6 +279,13 @@ export interface FreenetCallbacks {
   onGlobalPostsLoaded?: (posts: Post[]) => void;
   /** Optional: a single live public-timeline post from a global-index delta. */
   onNewGlobalPost?: (post: Post) => void;
+  /**
+   * Optional: authoritative reply list for a root post, derived from its
+   * thread shard GET. Fires whenever the thread shard is read (like/repost
+   * refresh or explicit subscribe delivery). The full reply set is passed so
+   * the caller can replace (not merge) its local replica.
+   */
+  onRepliesUpdated?: (rootPostId: string, replies: Post[]) => void;
 }
 
 export class FreenetConnection {
@@ -347,6 +365,8 @@ export class FreenetConnection {
   private pendingReposts: PendingRepost[] = [];
   /** Quote-refs awaiting a delegate `SignedQuoteRef`, keyed by nonce. */
   private pendingQuoteRefs: PendingQuoteRef[] = [];
+  /** Replies awaiting a delegate `Signed` response (SignReply), keyed by nonce. */
+  private pendingReplies: PendingReply[] = [];
 
   constructor(callbacks: FreenetCallbacks) {
     this.callbacks = callbacks;
@@ -480,6 +500,10 @@ export class FreenetConnection {
         this.emitLikeState(threadRoot, thread.likes ?? {});
         this.emitRepostState(threadRoot, thread.reposts ?? {});
         this.emitQuoteState(threadRoot, thread.quotes ?? {});
+        // Emit the full reply list so Thread.svelte can surface real replies.
+        const replies = Object.values(thread.replies ?? {}).map(contractPostToUiPost);
+        replies.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+        this.callbacks.onRepliesUpdated?.(threadRoot, replies);
         return;
       }
       // Global-index GET (public-timeline snapshot): the singleton's state is a
@@ -1384,6 +1408,140 @@ export class FreenetConnection {
     const idx = this.pendingQuoteRefs.findIndex((p) => p.nonce === nonce);
     if (idx === -1) return false;
     this.pendingQuoteRefs.splice(idx, 1);
+    return true;
+  }
+
+  /**
+   * Reply to a post. Derives/instantiates the root post's thread shard, then
+   * asks the delegate to sign a reply Post (via `SignReply`); the matching
+   * `SignedReply` response is routed to {@link completeReply}, which folds the signed
+   * post into the thread shard via `ThreadDelta::Replies`. Returns false if it
+   * cannot proceed (no shard / delegate). A reply is structurally a Post with
+   * `reply_to` set — there is no separate record type (see backend facts, #12).
+   */
+  async replyPost(rootPostId: string, content: string): Promise<boolean> {
+    if (!this.api || !this.currentUser) return false;
+    const key = this.threadKeyFor(rootPostId);
+    if (!key) {
+      console.warn("[thread] no thread-shard code hash — cannot reply");
+      return false;
+    }
+    try {
+      await this.ensureThreadShard(key, rootPostId);
+      this.subscribeThread(key);
+    } catch (e) {
+      console.error("[thread] ensure/subscribe failed:", e);
+      return false;
+    }
+    const nonce = crypto.randomUUID();
+    const timestamp = Date.now();
+    this.pendingReplies.push({
+      nonce,
+      rootPostId,
+      author_name: this.currentUser.name,
+      author_handle: this.currentUser.handle,
+      content,
+      timestamp,
+    });
+    const requested = signReply(
+      nonce,
+      content,
+      this.currentUser.name,
+      this.currentUser.handle,
+      timestamp,
+      rootPostId,
+    );
+    if (!requested) {
+      this.pendingReplies.pop();
+      console.warn("[thread] cannot reply: delegate not connected to sign");
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Complete a reply once the delegate returns a `Signed` response for a
+   * `SignReply` request. Mirrors {@link completeLike}: matches the pending entry
+   * by nonce, assembles the signed ContractPost (reply_to populated), and sends
+   * a `ThreadDelta::Replies` UpdateRequest to the root post's thread shard.
+   */
+  async completeReply(signed: {
+    nonce: string;
+    post_id: string;
+    signature: string;
+    public_key: string;
+  }): Promise<boolean> {
+    if (!this.api) return false;
+    const idx = this.pendingReplies.findIndex((p) => p.nonce === signed.nonce);
+    if (idx === -1) {
+      console.warn("[thread] Signed (reply) with no matching pending reply", signed.nonce);
+      return false;
+    }
+    const [pending] = this.pendingReplies.splice(idx, 1);
+    const key = this.threadKeyFor(pending.rootPostId);
+    if (!key) return false;
+
+    const post: ContractPost = {
+      id: signed.post_id,
+      author_pubkey: signed.public_key,
+      author_name: pending.author_name,
+      author_handle: pending.author_handle,
+      content: pending.content,
+      timestamp: pending.timestamp,
+      reply_to: pending.rootPostId,
+      signature: signed.signature,
+    };
+    try {
+      const deltaBytes = new TextEncoder().encode(
+        JSON.stringify({ Replies: [post] }),
+      );
+      const update = new UpdateData(
+        UpdateDataType.DeltaUpdate,
+        new DeltaUpdate(Array.from(deltaBytes)),
+      );
+      await this.api.update(new UpdateRequest(key, update));
+      // Refresh to pick up the updated reply count.
+      this.refreshLikesNow(pending.rootPostId);
+      return true;
+    } catch (e) {
+      console.error("[thread] failed to send reply:", e);
+      this.refreshLikesNow(pending.rootPostId);
+      return false;
+    }
+  }
+
+  /**
+   * Load the reply list for a thread. Called when the user opens a thread view
+   * so the reply list is populated even on a fresh page load (before any
+   * engagement action has been taken). Derives and registers the thread key,
+   * instantiates the shard if absent, subscribes for live deltas, then issues a
+   * GET so {@link handleGetResponse} fires {@link FreenetCallbacks.onRepliesUpdated}.
+   * Fire-and-forget: mirrors the {@link loadUserShard} / {@link loadGlobalIndex}
+   * pattern. A spurious re-PUT over an already-instantiated shard is a harmless
+   * CRDT merge (see the comment at ensureThreadShard line 663–665).
+   */
+  loadThreadReplies(rootPostId: string): void {
+    const key = this.threadKeyFor(rootPostId);
+    if (!key) {
+      console.warn("[thread] no thread-shard code hash — cannot load replies");
+      return;
+    }
+    this.ensureThreadShard(key, rootPostId)
+      .then(() => {
+        this.subscribeThread(key);
+        this.refreshLikesNow(rootPostId);
+      })
+      .catch((e) => console.error("[thread] loadThreadReplies failed:", e));
+  }
+
+  /**
+   * Drop a pending reply by nonce (delegate returned an Error for it). Returns
+   * true if a pending reply was actually dropped. Mirror of {@link dropPendingLike}.
+   */
+  dropPendingReply(nonce: string): boolean {
+    const idx = this.pendingReplies.findIndex((p) => p.nonce === nonce);
+    if (idx === -1) return false;
+    this.pendingReplies.splice(idx, 1);
     return true;
   }
 

--- a/web/src/identity.ts
+++ b/web/src/identity.ts
@@ -173,6 +173,36 @@ export function signQuoteRef(
   return true;
 }
 
+/**
+ * Ask the delegate to sign a reply post. Structurally identical to a regular
+ * post but the `reply_to` field is populated (the content-address of the root
+ * post being replied to). The delegate sends a `SignReply` request and replies
+ * with a `SignedReply` response routed through onDelegateResponse →
+ * freenet-api completeReply. Returns false if no delegate (cannot sign offline).
+ */
+export function signReply(
+  nonce: string,
+  content: string,
+  authorName: string,
+  authorHandle: string,
+  timestamp: number,
+  replyTo: string,
+  quotedPost = ""
+): boolean {
+  if (!isDelegateConnected()) return false;
+  sendIdentityMessage(delegateApi!, delegateKeyBytes!, delegateCodeHashBytes!, {
+    type: "SignReply",
+    nonce,
+    content,
+    author_name: authorName,
+    author_handle: authorHandle,
+    timestamp,
+    reply_to: replyTo,
+    quoted_post: quotedPost,
+  }).catch((e) => console.warn("[identity] SignReply failed:", e));
+  return true;
+}
+
 export function exportIdentity(): void {
   if (!isDelegateConnected()) {
     // Offline / no delegate: synthesize a placeholder so the modal still appears

--- a/web/src/stores/freenet.ts
+++ b/web/src/stores/freenet.ts
@@ -64,6 +64,12 @@ export const showOnboarding = writable<boolean>(false);
  * clears to null on close. Replaces the imperative showKeyExportModal() call.
  */
 export const keyExportSecret = writable<string | null>(null);
+/**
+ * Authoritative replies for each thread, keyed by root post id. Written by
+ * the onRepliesUpdated callback whenever a thread shard is read. Thread.svelte
+ * derives its reply list from this store (not from the feed posts list).
+ */
+export const threadReplies = writable<Map<string, Post[]>>(new Map());
 
 // ---------------------------------------------------------------------------
 // Module-private latches / dedup sets (plain `let`/`const`, NOT stores) —
@@ -222,6 +228,13 @@ export const connection = new FreenetConnection({
       return [...cur];
     });
   },
+  onRepliesUpdated: (rootPostId: string, replies: Post[]) => {
+    threadReplies.update((cur) => {
+      const next = new Map(cur);
+      next.set(rootPostId, replies);
+      return next;
+    });
+  },
   onDelegateResponse: (response: DelegateResponse) => {
     const payloads = parseDelegateResponse(response);
     for (const payload of payloads) {
@@ -238,7 +251,9 @@ export const connection = new FreenetConnection({
         return;
       }
 
-      // A signed post came back from the delegate — finish publishing it.
+      // A signed post (or reply) came back from the delegate. Try completeReply
+      // first (matches by nonce against pendingReplies); if it returns false the
+      // nonce belongs to a regular publish — route there instead.
       const signed = payload as {
         type?: string;
         nonce?: string;
@@ -247,20 +262,33 @@ export const connection = new FreenetConnection({
         public_key?: string;
       };
       if (
-        signed.type === "Signed" &&
+        (signed.type === "Signed" || signed.type === "SignedReply") &&
         signed.nonce &&
         signed.post_id &&
         signed.signature &&
         signed.public_key
       ) {
         connection
-          .completePublish({
+          .completeReply({
             nonce: signed.nonce,
             post_id: signed.post_id,
             signature: signed.signature,
             public_key: signed.public_key,
           })
-          .catch((e) => console.error("[delegate] completePublish failed:", e));
+          .then((handled) => {
+            if (!handled) {
+              // Not a reply — route to the regular publish path.
+              connection
+                .completePublish({
+                  nonce: signed.nonce!,
+                  post_id: signed.post_id!,
+                  signature: signed.signature!,
+                  public_key: signed.public_key!,
+                })
+                .catch((e) => console.error("[delegate] completePublish failed:", e));
+            }
+          })
+          .catch((e) => console.error("[delegate] completeReply failed:", e));
         return;
       }
 
@@ -375,6 +403,7 @@ export const connection = new FreenetConnection({
           if (connection.dropPendingLike(p.nonce)) refreshFeed();
           if (connection.dropPendingRepost(p.nonce)) refreshFeed();
           connection.dropPendingQuoteRef(p.nonce);
+          connection.dropPendingReply(p.nonce);
         }
         if (p.message?.includes("no identity")) {
           console.log("[identity] No identity in delegate — show onboarding");
@@ -476,6 +505,26 @@ export function quote(postId: string, content: string): void {
       setTimeout(() => connection.loadState(), 300);
     }
   });
+}
+
+export function reply(rootPostId: string, content: string): void {
+  connection.replyPost(rootPostId, content).then((ok) => {
+    if (!ok) {
+      console.warn("[freenet] Reply not sent (no delegate / shard)");
+    }
+    // On success the reply surfaces via completeReply → thread-shard refresh →
+    // onRepliesUpdated (the threadReplies store), not via a user-shard reload —
+    // the reply lives in the thread shard, so loadState() would be a no-op here.
+  });
+}
+
+/**
+ * Trigger a thread-shard load for the given root post so the reply list is
+ * populated even on a fresh page load (before any engagement action). Mirrors
+ * the like/repost pattern: fire-and-forget, errors are logged in the connection.
+ */
+export function loadThreadReplies(rootPostId: string): void {
+  connection.loadThreadReplies(rootPostId);
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -12,6 +12,8 @@ export interface Post {
   quotes?: number;
   /** Content address of the post this one quotes, if it is a quote repost. */
   quotedPostId?: string;
+  /** Content address of the post this one replies to (maps to contract reply_to). */
+  replyToId?: string;
 }
 
 export interface User {

--- a/web/tests/node-e2e/reply-thread.spec.ts
+++ b/web/tests/node-e2e/reply-thread.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect, type Page, type FrameLocator } from "@playwright/test";
+
+// End-to-end reply flow against a LIVE Freenet node (booted + published by
+// scripts/node-e2e.sh). Tests the full reply path:
+//   web UI compose-box → SignReply delegate variant → ThreadDelta::Replies →
+//   thread-shard contract → thread view renders .thread-reply.
+//
+// Serial, single-node (workers:1), same shared delegate across tests in this
+// file. The "cross-session" test exercises the reload-GET seam (#50) which may
+// fail on a single-node setup; it is intentionally a SEPARATE test so the
+// same-session assertion can pass independently.
+
+/** The packaged app runs inside the sandboxed loader iframe. */
+function app(page: Page): FrameLocator {
+  return page.frameLocator("iframe#app");
+}
+
+/** Collect WS urls + console for connection assertions. */
+function instrument(page: Page) {
+  const ws: string[] = [];
+  const logs: string[] = [];
+  page.on("websocket", (s) => ws.push(s.url()));
+  page.on("console", (m) => logs.push(`[${m.type()}] ${m.text()}`));
+  page.on("pageerror", (e) => logs.push(`[pageerror] ${e.message}`));
+  return { ws, logs };
+}
+
+test.beforeEach(({ baseURL }) => {
+  expect(
+    baseURL,
+    "BASE_URL must be the node-served webapp URL — run via `cargo make test-ui-node-e2e`",
+  ).toBeTruthy();
+});
+
+/**
+ * Drive the app to the logged-in shell, tolerant of shared-node state. If the
+ * delegate has no identity yet, onboarding shows and we register; if a prior
+ * spec already created one, the shell is already up and we just wait for it.
+ * Returns the app FrameLocator with the sidebar visible.
+ */
+async function ensureAppShell(page: Page, displayName: string): Promise<FrameLocator> {
+  const a = app(page);
+  const onboarding = a.locator(".onboarding-overlay");
+  const sidebar = a.locator("aside.sidebar");
+  await expect
+    .poll(async () => (await onboarding.count()) > 0 || (await sidebar.count()) > 0, {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+  if ((await onboarding.count()) > 0 && (await sidebar.count()) === 0) {
+    await a.locator(".onboarding-input").first().fill(displayName);
+    const join = a.locator(".onboarding-btn", { hasText: "Join" });
+    await expect(join).toBeEnabled({ timeout: 10_000 });
+    await join.click();
+  }
+  await expect(sidebar).toBeVisible({ timeout: 45_000 });
+  return a;
+}
+
+/**
+ * Ensure at least one post exists in the Following feed.
+ * If the feed is empty (following-note visible), compose one and wait for it.
+ */
+async function ensurePostExists(a: FrameLocator): Promise<void> {
+  const feedPosts = a.locator(".feed__posts .post");
+  const emptyNote = a.locator(".feed__posts .following-note__title", {
+    hasText: "Nothing here yet",
+  });
+
+  // Wait until the feed settles: either posts appear or the empty-note shows.
+  await expect
+    .poll(
+      async () => {
+        const postCount = await feedPosts.count();
+        const emptyCount = await emptyNote.count();
+        return postCount > 0 || emptyCount > 0;
+      },
+      { timeout: 20_000 },
+    )
+    .toBeTruthy();
+
+  // If the feed is still empty after settling, compose a seed post.
+  if ((await feedPosts.count()) === 0) {
+    await a.locator(".quickpost").click();
+    await expect(a.locator(".compose-modal-overlay")).toBeVisible({ timeout: 10_000 });
+    await a.locator(".compose-modal__textarea").fill("seed post for reply e2e");
+    const postBtn = a.locator(".compose-modal__post");
+    await expect(postBtn).toBeEnabled({ timeout: 10_000 });
+    await postBtn.click();
+    await expect(a.locator(".compose-modal-overlay")).toBeHidden({ timeout: 15_000 });
+    // Wait for the seed post to appear in the feed. The first PUT on a cold
+    // node (user-shard instantiate → write → subscription delta) can exceed
+    // 30s, so allow the same 90s budget the reply round-trip uses.
+    await expect(feedPosts.first()).toBeVisible({ timeout: 90_000 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — same-session: compose a reply and see it in the thread reply list.
+// ---------------------------------------------------------------------------
+test("reply appears in thread view (same session)", async ({ page }) => {
+  const { logs } = instrument(page);
+  await page.goto("", { waitUntil: "domcontentloaded" });
+  const a = await ensureAppShell(page, "Reply Tester");
+
+  // Wait for the live delegate to confirm identity is known.
+  await expect
+    .poll(() => logs.some((l) => l.includes("[identity] Delegate connection wired")), {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+
+  // Ensure there is at least one post to reply to.
+  await ensurePostExists(a);
+
+  // Open the first post's thread by clicking the reply-button (post-act--reply)
+  // in the PostCard. The button calls onOpen(post) which sets threadRoot.
+  const firstPost = a.locator(".feed__posts .post").first();
+  await expect(firstPost).toBeVisible({ timeout: 15_000 });
+  await firstPost.locator(".post-act--reply").click();
+
+  // Thread view renders inside the same feed-column (replaces the feed).
+  await expect(a.locator(".thread-head")).toBeVisible({ timeout: 15_000 });
+
+  // Compose a reply with a unique marker.
+  const marker = `e2e-reply-${Date.now()}`;
+  const replyField = a.locator(".thread-compose__field");
+  await expect(replyField).toBeVisible({ timeout: 10_000 });
+  await replyField.fill(marker);
+  const replyBtn = a.locator(".thread-compose__btn");
+  await expect(replyBtn).toBeEnabled({ timeout: 5_000 });
+  await replyBtn.click();
+
+  // The reply textarea should clear after submit.
+  await expect(replyField).toHaveValue("", { timeout: 5_000 });
+
+  // SAME-SESSION assert: the reply list (.thread-reply) should contain the
+  // marker text. The thread shard is written + the subscription delivers the
+  // ThreadDelta::Replies back to the same session before a full reload is needed.
+  await expect
+    .poll(
+      async () => a.locator(".thread-reply .thread-reply__text").getByText(marker).count(),
+      {
+        // Cold-node delegate-sign → thread-shard PUT → subscription delta
+        // round-trip can exceed 30s on first use (matches the 90s poll the
+        // live-node post round-trip uses for the same reason).
+        timeout: 90_000,
+        message: "reply did not appear in .thread-reply list (same session)",
+      },
+    )
+    .toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — cross-session: reload and verify the reply persisted.
+//
+// This exercises the #50 reload-GET seam: after a page.reload() the app
+// re-GETs the thread shard from the node and must deserialise the persisted
+// ThreadDelta::Replies. On a single-node setup the GET may fail if the shard
+// was not yet finalised; this test is intentionally SEPARATE so that test 1
+// can pass even when the cross-session GET is broken.
+// ---------------------------------------------------------------------------
+test("reply persists across page reload (cross-session — #50 seam, may fail on single-node)", async ({
+  page,
+}) => {
+  // Boot the app and get to a known post; the shared delegate already has an
+  // identity from the same-session test above (serial workers:1 node).
+  const { logs } = instrument(page);
+  await page.goto("", { waitUntil: "domcontentloaded" });
+  const a = await ensureAppShell(page, "Reply Tester Reload");
+
+  await expect
+    .poll(() => logs.some((l) => l.includes("[identity] Delegate connection wired")), {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
+
+  await ensurePostExists(a);
+
+  // Open the first post's thread.
+  const firstPost = a.locator(".feed__posts .post").first();
+  await expect(firstPost).toBeVisible({ timeout: 15_000 });
+  await firstPost.locator(".post-act--reply").click();
+  await expect(a.locator(".thread-head")).toBeVisible({ timeout: 15_000 });
+
+  // Compose a FRESH marker for this test (distinct from the same-session run).
+  const marker = `e2e-reply-reload-${Date.now()}`;
+  const replyField = a.locator(".thread-compose__field");
+  await expect(replyField).toBeVisible({ timeout: 10_000 });
+  await replyField.fill(marker);
+  const replyBtn = a.locator(".thread-compose__btn");
+  await expect(replyBtn).toBeEnabled({ timeout: 5_000 });
+  await replyBtn.click();
+  await expect(replyField).toHaveValue("", { timeout: 5_000 });
+
+  // Wait for the reply to appear in the same session first (gives the shard
+  // time to be written before we reload).
+  await expect
+    .poll(
+      async () => a.locator(".thread-reply .thread-reply__text").getByText(marker).count(),
+      { timeout: 90_000, message: "reply did not appear in same-session (pre-reload)" },
+    )
+    .toBeGreaterThan(0);
+
+  // CROSS-SESSION assert: reload the page, navigate back to the same thread,
+  // and verify the reply is still rendered.
+  // NOTE: this is the #50 seam — the reload-GET of the thread shard is not
+  // guaranteed to succeed on a single-node setup. Generous 30 s poll.
+  await page.reload({ waitUntil: "domcontentloaded" });
+  const a2 = await ensureAppShell(page, "Reply Tester Reload");
+  await ensurePostExists(a2);
+  const firstPost2 = a2.locator(".feed__posts .post").first();
+  await expect(firstPost2).toBeVisible({ timeout: 20_000 });
+  await firstPost2.locator(".post-act--reply").click();
+  await expect(a2.locator(".thread-head")).toBeVisible({ timeout: 15_000 });
+
+  await expect
+    .poll(
+      async () => a2.locator(".thread-reply .thread-reply__text").getByText(marker).count(),
+      {
+        timeout: 30_000,
+        message:
+          "reply did not survive page reload — this is the #50 single-node reload-GET seam",
+      },
+    )
+    .toBeGreaterThan(0);
+});


### PR DESCRIPTION
## What

Wires the **reply** path end-to-end — the last unwired engagement action. The thread-shard contract already validated `ThreadDelta::Replies`, but the delegate couldn't sign a reply (`build_signed_post` hardcoded `reply_to=""`) and `onThreadReply` was a no-op that mislabeled quote-reposts as replies.

## Delegate (`delegates/identity`)
- `SignReply` request + `SignedReply` response + `build_signed_reply` helper populating `reply_to` (and optional `quoted_post`). `SignPost` stays **byte-identical** (top-level posts keep empty `reply_to`, so existing signatures are unaffected).
- Unit tests: reply verifies; rebinding to another thread breaks verification; reply+quote payload byte order; reply vs top-level payloads differ.

## Web
- `Post.replyToId` + `signReply` wrapper.
- `FreenetConnection.replyPost`/`completeReply`: sign, then PUT `ThreadDelta::Replies` to the thread shard; surfaced via `onRepliesUpdated`. Inbound `ContractPost.reply_to` → `replyToId`.
- `threadReplies` store fed by `onRepliesUpdated`; `App.svelte` sources **real** replies from the thread shard (not quote-reposts) and eagerly GETs the thread shard on `openThread` so replies render on first open.
- Dropped the redundant `loadState()` from `reply()` (replies live in the thread shard).

## Tests — local isolated network
- `web/tests/node-e2e/reply-thread.spec.ts`: **same-session** reply round-trip + **cross-session reload** (the #50 single-node reload-GET seam), driven against a live throwaway node via `cargo make test-ui-node-e2e`. Cold-node round-trips use a 90s poll budget (matches the existing live-node round-trip).
- `scripts/node-e2e.sh`: optional `PLAYWRIGHT_GREP` to run a single spec.

## Verification
- `cargo make clippy` (-D warnings) ✅ · `fmt-check` ✅
- `cargo make test` — rust workspace (incl. new reply tests in common/identity/thread-shard) + web vitest (40) ✅
- `cargo make test-ui-node-e2e` — **both reply tests pass** (same-session + cross-session reload). The only flaky spec is the pre-existing live-node Discover round-trip (#50 propagation seam), unrelated to this change.

Addresses #12; advances #8.

https://claude.ai/code/session_01Q6rfcR7TYVpMCTELqr6kWv